### PR TITLE
Rapid OS v2: agent adapter architecture foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Este proyecto está construido utilizando tecnologías nativas para asegurar má
 - **🧰 Gestor de Skills Híbrido**: Instala capacidades activas para tu IA desde dos fuentes:
   - _Remoto_: Acceso directo al ecosistema de la comunidad (`npx skills`) para instalar miles de herramientas.
   - _Local_: Usa tus propios templates privados (`templates/skills`) para estandarizar flujos de tu equipo.
-- **🤖 Multi-Agente Modular**: No más ruido. Elige exactamente qué archivos de configuración generar: Cursor (`.cursorrules`), Claude Code (`CLAUDE.md`), Google Antigravity (`.agent/rules`) o VS Code.
+- **🤖 Multi-Agente Modular**: No más ruido. Elige exactamente qué archivos de configuración generar: Cursor (`.cursorrules`), Claude Code (`CLAUDE.md`), Google Antigravity (`.agent/rules`) o VS Code. La generación usa adaptadores internos para mantener cada agente aislado y listo para crecer sin cambiar tus comandos.
 - **🧠 Contexto de Negocio Inteligente**: Importa tus reglas de negocio desde archivos Markdown (`.md`) existentes o guárdalas como Plantillas reutilizables para futuros proyectos.
 - **🏗️ Topologías Arquitectónicas**: Define si tu proyecto es Frontend Only, BaaS (Supabase), Fullstack Separado o **Sitio de Documentación** para evitar alucinaciones de código.
 - **🔌 Herramientas MCP (Model Context Protocol)**: Configura automáticamente servidores de base de datos (Postgres/Supabase) y herramientas de investigación (Context7, Firecrawl).

--- a/docs/architecture/rapid-os-v2.md
+++ b/docs/architecture/rapid-os-v2.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Issue #6 starts the Rapid OS v2 migration with extraction, not a rewrite. The CLI keeps the same command names and file outputs, while reusable logic moves out of the historical `rapid.py` monolith into a small package structure that can be tested independently.
+Issue #6 started the Rapid OS v2 migration with extraction, not a rewrite. Issue #7 adds the first formal adapter boundary for generated agent context files while keeping the same CLI commands, project config, and generated file outputs.
 
 `rapid.py` remains the compatibility entrypoint because the existing install scripts and user aliases execute it directly. It now delegates to the package CLI and re-exports compatibility constants/functions for existing import users.
 
@@ -14,26 +14,48 @@ Issue #6 starts the Rapid OS v2 migration with extraction, not a rewrite. The CL
 - `rapid_os.core.filesystem` contains reusable filesystem/process helpers such as timestamped backups and `npx` detection.
 - `rapid_os.core.context` composes standards and visual context in the existing priority order.
 - `rapid_os.core.output` contains shared CLI output helpers.
-- `rapid_os.domain.agents` writes generated context files for Cursor, Claude, Antigravity, and VS Code.
-- `rapid_os.adapters` is intentionally empty in this PR and reserved for future first-class adapter work.
+- `rapid_os.domain.agents` is now a compatibility facade for the existing generation helpers.
+- `rapid_os.adapters.agents` owns the agent adapter contract, default registry, and implementations for Cursor, Claude, Antigravity, and VS Code.
 
 The package modules avoid command execution on import. Console UTF-8 setup happens when the CLI entrypoint runs, so importing reusable helpers remains lightweight for tests and future integrations.
+
+## Agent Adapter Architecture
+
+Agent-specific project context generation now flows through `AgentAdapter` implementations. Each adapter declares:
+
+- A stable tool id matching `.rapid-os/config.json`, such as `cursor` or `claude`.
+- Generated output files through `AgentOutput`.
+- Rendering behavior for the context payload.
+- Activation and placement behavior through the base `activate()` flow, including parent directory creation, backup creation, UTF-8 writes, and the existing success messages.
+- Optional metadata for user-facing or future orchestration needs.
+
+The default registry preserves the previous generation order: Cursor, Claude, Antigravity, then VS Code. Unknown tool ids remain ignored during context generation, which keeps research tool config entries such as `context7` and `firecrawl` compatible with the existing project config shape.
+
+Supported adapters in issue #7:
+
+- Cursor: `.cursorrules`
+- Claude Code: `CLAUDE.md`
+- Google Antigravity: `.agent/rules/constitution.md`
+- VS Code / Copilot: `INSTRUCTIONS.md`
 
 ## Compatibility Guarantees
 
 - Existing commands remain available: `init`, `skill`, `mcp`, `scope`, `deploy`, `vision`, `refine`, `guide`, and the current `prompt` command.
 - Existing aliases that call `python rapid.py` continue to work.
 - Existing import users can still read common compatibility constants from `rapid.py`, including `SCRIPT_DIR`, `TEMPLATES_DIR`, `CURRENT_DIR`, `PROJECT_RAPID_DIR`, and `CONFIG_FILE`.
+- Existing import users can still call `generate_cursor_rules`, `generate_claude_config`, `generate_antigravity_config`, and `generate_vscode_instructions`; those helpers now delegate to adapters.
 - Generated files remain in their current locations: `.cursorrules`, `CLAUDE.md`, `.agent/rules/constitution.md`, `INSTRUCTIONS.md`, `claude_desktop_config.json`, `SPECS.md`, `DEPLOY.md`, and `references/VISION_CONTEXT.md`.
 - Project config remains `.rapid-os/config.json`.
 - Template discovery still prefers a source checkout `templates/` directory and falls back to `~/.rapid-os/templates`.
 
 ## Intentionally Unchanged
 
-This PR does not introduce first-class Codex support, redesign MCP generation, redesign scope/spec workflows, add validation commands, change install scripts, or create a full agent adapter system.
+This PR does not introduce first-class Codex support, redesign MCP generation, redesign scope/spec workflows, add validation commands, or change install scripts.
 
 Some command workflows still live in `rapid_os.cli.main` because moving them wholesale into new abstractions would be a larger behavior-changing rewrite. The priority here is to isolate reusable logic first, then migrate command domains incrementally.
 
 ## Remaining Migration Work
 
-The next PR should introduce an explicit agent adapter interface and move Cursor, Claude, Antigravity, VS Code, and future Codex behavior behind it. After that, command flows can be split further by domain once the adapter boundary is stable.
+Issue #8 should add first-class Codex support behind the same adapter contract. That work should define Codex output files, activation semantics, skill placement expectations, and any metadata needed by the CLI before adding `codex` to default project configuration.
+
+After Codex is added, command flows can be split further by domain once the adapter boundary is stable.

--- a/rapid_os/adapters/__init__.py
+++ b/rapid_os/adapters/__init__.py
@@ -1,2 +1,2 @@
-"""Future adapter integrations for Rapid OS."""
+"""Adapter integrations for Rapid OS."""
 

--- a/rapid_os/adapters/agents/__init__.py
+++ b/rapid_os/adapters/agents/__init__.py
@@ -1,0 +1,16 @@
+"""Agent adapters for Rapid OS generated context files."""
+
+from rapid_os.adapters.agents.base import AgentAdapter, AgentOutput
+from rapid_os.adapters.agents.registry import (
+    DEFAULT_AGENT_REGISTRY,
+    AgentRegistry,
+    create_default_agent_registry,
+)
+
+__all__ = [
+    "AgentAdapter",
+    "AgentOutput",
+    "AgentRegistry",
+    "DEFAULT_AGENT_REGISTRY",
+    "create_default_agent_registry",
+]

--- a/rapid_os/adapters/agents/base.py
+++ b/rapid_os/adapters/agents/base.py
@@ -1,0 +1,50 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+from rapid_os.core.filesystem import create_backup
+from rapid_os.core.output import print_success
+
+
+@dataclass(frozen=True)
+class AgentOutput:
+    """A file produced by an agent adapter."""
+
+    relative_path: Path
+    success_message: str
+    encoding: str = "utf-8"
+
+
+class AgentAdapter(ABC):
+    """Base contract for agents that consume Rapid OS project context."""
+
+    id: str
+    name: str
+    metadata: Mapping[str, str] = {}
+    outputs: tuple[AgentOutput, ...] = ()
+
+    @property
+    def output_files(self):
+        return tuple(output.relative_path for output in self.outputs)
+
+    @abstractmethod
+    def render(self, context: str) -> Mapping[Path, str]:
+        """Return generated content keyed by relative output path."""
+
+    def activate(self, context: str, current_dir: Path) -> None:
+        """Render and place the adapter outputs in a project directory."""
+        rendered_outputs = self.render(context)
+
+        for output in self.outputs:
+            relative_path = output.relative_path
+            if relative_path not in rendered_outputs:
+                raise KeyError(
+                    f"Adapter '{self.id}' did not render '{relative_path.as_posix()}'."
+                )
+
+            target = current_dir / relative_path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            create_backup(target)
+            target.write_text(rendered_outputs[relative_path], encoding=output.encoding)
+            print_success(output.success_message)

--- a/rapid_os/adapters/agents/implementations.py
+++ b/rapid_os/adapters/agents/implementations.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+from typing import Mapping
+
+from rapid_os.adapters.agents.base import AgentAdapter, AgentOutput
+
+
+class CursorAdapter(AgentAdapter):
+    id = "cursor"
+    name = "Cursor"
+    metadata = {"activation": "Project root .cursorrules"}
+    outputs = (
+        AgentOutput(Path(".cursorrules"), "Generado: .cursorrules"),
+    )
+
+    def render(self, context: str) -> Mapping[Path, str]:
+        return {
+            Path(".cursorrules"): (
+                "# RAPID OS - SYSTEM CONTEXT\n"
+                "# DO NOT EDIT. Generated automatically.\n\n"
+                f"{context}"
+            )
+        }
+
+
+class ClaudeAdapter(AgentAdapter):
+    id = "claude"
+    name = "Claude Code"
+    metadata = {"activation": "Project root CLAUDE.md"}
+    outputs = (
+        AgentOutput(Path("CLAUDE.md"), "Generado: CLAUDE.md"),
+    )
+
+    def render(self, context: str) -> Mapping[Path, str]:
+        return {
+            Path("CLAUDE.md"): (
+                "# PROJECT MEMORY\n"
+                "# SOURCE OF TRUTH FOR AI.\n\n"
+                f"{context}"
+            )
+        }
+
+
+class AntigravityAdapter(AgentAdapter):
+    id = "antigravity"
+    name = "Google Antigravity"
+    metadata = {"activation": "Always-on project constitution rule"}
+    outputs = (
+        AgentOutput(
+            Path(".agent") / "rules" / "constitution.md",
+            "Generado: .agent/rules/constitution.md",
+        ),
+    )
+
+    def render(self, context: str) -> Mapping[Path, str]:
+        relative_path = Path(".agent") / "rules" / "constitution.md"
+        return {
+            relative_path: (
+                "# PROJECT CONSTITUTION\n"
+                "# ACTIVATION: ALWAYS_ON\n\n"
+                "# IMMUTABLE TRUTH FOR GEMINI AGENTS.\n"
+                f"{context}"
+            )
+        }
+
+
+class VSCodeAdapter(AgentAdapter):
+    id = "vscode"
+    name = "VS Code / Copilot"
+    metadata = {"activation": "Project root INSTRUCTIONS.md"}
+    outputs = (
+        AgentOutput(Path("INSTRUCTIONS.md"), "Generado: INSTRUCTIONS.md"),
+    )
+
+    def render(self, context: str) -> Mapping[Path, str]:
+        return {
+            Path("INSTRUCTIONS.md"): (
+                "# AI INSTRUCTIONS (COPILOT)\n\n"
+                f"{context}"
+            )
+        }
+
+
+SUPPORTED_AGENT_ADAPTERS = (
+    CursorAdapter,
+    ClaudeAdapter,
+    AntigravityAdapter,
+    VSCodeAdapter,
+)

--- a/rapid_os/adapters/agents/registry.py
+++ b/rapid_os/adapters/agents/registry.py
@@ -1,0 +1,43 @@
+from collections import OrderedDict
+from typing import Iterable
+
+from rapid_os.adapters.agents.base import AgentAdapter
+from rapid_os.adapters.agents.implementations import SUPPORTED_AGENT_ADAPTERS
+
+
+class AgentRegistry:
+    """Ordered registry for project-context agent adapters."""
+
+    def __init__(self, adapters: Iterable[AgentAdapter] = ()):
+        self._adapters = OrderedDict()
+        for adapter in adapters:
+            self.register(adapter)
+
+    def register(self, adapter: AgentAdapter) -> None:
+        if adapter.id in self._adapters:
+            raise ValueError(f"Agent adapter already registered: {adapter.id}")
+        self._adapters[adapter.id] = adapter
+
+    def get(self, agent_id: str) -> AgentAdapter:
+        return self._adapters[agent_id]
+
+    def ids(self):
+        return tuple(self._adapters.keys())
+
+    def adapters(self):
+        return tuple(self._adapters.values())
+
+    def enabled(self, selected_ids: Iterable[str]):
+        selected = set(selected_ids)
+        return tuple(
+            adapter
+            for adapter_id, adapter in self._adapters.items()
+            if adapter_id in selected
+        )
+
+
+def create_default_agent_registry() -> AgentRegistry:
+    return AgentRegistry(adapter_cls() for adapter_cls in SUPPORTED_AGENT_ADAPTERS)
+
+
+DEFAULT_AGENT_REGISTRY = create_default_agent_registry()

--- a/rapid_os/domain/agents.py
+++ b/rapid_os/domain/agents.py
@@ -1,50 +1,24 @@
-from rapid_os.core.filesystem import create_backup
-from rapid_os.core.output import print_success
+from rapid_os.adapters.agents import DEFAULT_AGENT_REGISTRY
 from rapid_os.core.paths import CURRENT_DIR
 
 
 def generate_cursor_rules(context, current_dir=CURRENT_DIR):
-    target = current_dir / ".cursorrules"
-    create_backup(target)
-    content = f"# RAPID OS - SYSTEM CONTEXT\n# DO NOT EDIT. Generated automatically.\n\n{context}"
-    target.write_text(content, encoding="utf-8")
-    print_success("Generado: .cursorrules")
+    DEFAULT_AGENT_REGISTRY.get("cursor").activate(context, current_dir)
 
 
 def generate_claude_config(context, current_dir=CURRENT_DIR):
-    target = current_dir / "CLAUDE.md"
-    create_backup(target)
-    content = f"# PROJECT MEMORY\n# SOURCE OF TRUTH FOR AI.\n\n{context}"
-    target.write_text(content, encoding="utf-8")
-    print_success("Generado: CLAUDE.md")
+    DEFAULT_AGENT_REGISTRY.get("claude").activate(context, current_dir)
 
 
 def generate_antigravity_config(context, current_dir=CURRENT_DIR):
-    antigravity_dir = current_dir / ".agent" / "rules"
-    antigravity_dir.mkdir(parents=True, exist_ok=True)
-    target = antigravity_dir / "constitution.md"
-    create_backup(target)
-    header = "# PROJECT CONSTITUTION\n# ACTIVATION: ALWAYS_ON\n\n"
-    content = header + f"# IMMUTABLE TRUTH FOR GEMINI AGENTS.\n{context}"
-    target.write_text(content, encoding="utf-8")
-    print_success("Generado: .agent/rules/constitution.md")
+    DEFAULT_AGENT_REGISTRY.get("antigravity").activate(context, current_dir)
 
 
 def generate_vscode_instructions(context, current_dir=CURRENT_DIR):
-    target = current_dir / "INSTRUCTIONS.md"
-    create_backup(target)
-    content = f"# AI INSTRUCTIONS (COPILOT)\n\n{context}"
-    target.write_text(content, encoding="utf-8")
-    print_success("Generado: INSTRUCTIONS.md")
+    DEFAULT_AGENT_REGISTRY.get("vscode").activate(context, current_dir)
 
 
 def generate_agent_contexts(context, tools, current_dir=CURRENT_DIR):
-    if "cursor" in tools:
-        generate_cursor_rules(context, current_dir)
-    if "claude" in tools:
-        generate_claude_config(context, current_dir)
-    if "antigravity" in tools:
-        generate_antigravity_config(context, current_dir)
-    if "vscode" in tools:
-        generate_vscode_instructions(context, current_dir)
+    for adapter in DEFAULT_AGENT_REGISTRY.enabled(tools):
+        adapter.activate(context, current_dir)
 

--- a/tests/test_agent_adapters.py
+++ b/tests/test_agent_adapters.py
@@ -1,0 +1,126 @@
+import io
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from rapid_os.adapters.agents import DEFAULT_AGENT_REGISTRY, create_default_agent_registry
+from rapid_os.domain.agents import (
+    generate_agent_contexts,
+    generate_antigravity_config,
+    generate_claude_config,
+    generate_cursor_rules,
+    generate_vscode_instructions,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def workspace_tempdir():
+    return tempfile.TemporaryDirectory(dir=REPO_ROOT)
+
+
+def generate_quietly(func, *args):
+    with redirect_stdout(io.StringIO()):
+        func(*args)
+
+
+class AgentAdapterTests(unittest.TestCase):
+    def test_default_registry_contains_supported_v2_agents(self):
+        registry = create_default_agent_registry()
+
+        self.assertEqual(
+            registry.ids(),
+            ("cursor", "claude", "antigravity", "vscode"),
+        )
+
+    def test_adapters_declare_output_files_and_metadata(self):
+        self.assertEqual(
+            DEFAULT_AGENT_REGISTRY.get("cursor").output_files,
+            (Path(".cursorrules"),),
+        )
+        self.assertEqual(
+            DEFAULT_AGENT_REGISTRY.get("claude").output_files,
+            (Path("CLAUDE.md"),),
+        )
+        self.assertEqual(
+            DEFAULT_AGENT_REGISTRY.get("antigravity").output_files,
+            (Path(".agent") / "rules" / "constitution.md",),
+        )
+        self.assertEqual(
+            DEFAULT_AGENT_REGISTRY.get("vscode").output_files,
+            (Path("INSTRUCTIONS.md"),),
+        )
+        self.assertIn("activation", DEFAULT_AGENT_REGISTRY.get("cursor").metadata)
+
+    def test_legacy_wrappers_render_existing_file_contents(self):
+        with workspace_tempdir() as tmp:
+            current_dir = Path(tmp)
+            context = "project context"
+
+            generate_quietly(generate_cursor_rules, context, current_dir)
+            generate_quietly(generate_claude_config, context, current_dir)
+            generate_quietly(generate_antigravity_config, context, current_dir)
+            generate_quietly(generate_vscode_instructions, context, current_dir)
+
+            self.assertEqual(
+                (current_dir / ".cursorrules").read_text(encoding="utf-8"),
+                "# RAPID OS - SYSTEM CONTEXT\n"
+                "# DO NOT EDIT. Generated automatically.\n\n"
+                "project context",
+            )
+            self.assertEqual(
+                (current_dir / "CLAUDE.md").read_text(encoding="utf-8"),
+                "# PROJECT MEMORY\n"
+                "# SOURCE OF TRUTH FOR AI.\n\n"
+                "project context",
+            )
+            self.assertEqual(
+                (current_dir / ".agent" / "rules" / "constitution.md").read_text(
+                    encoding="utf-8"
+                ),
+                "# PROJECT CONSTITUTION\n"
+                "# ACTIVATION: ALWAYS_ON\n\n"
+                "# IMMUTABLE TRUTH FOR GEMINI AGENTS.\n"
+                "project context",
+            )
+            self.assertEqual(
+                (current_dir / "INSTRUCTIONS.md").read_text(encoding="utf-8"),
+                "# AI INSTRUCTIONS (COPILOT)\n\n"
+                "project context",
+            )
+
+    def test_generate_agent_contexts_uses_registered_agents_and_ignores_unknown_tools(self):
+        with workspace_tempdir() as tmp:
+            current_dir = Path(tmp)
+
+            generate_quietly(
+                generate_agent_contexts,
+                "project context",
+                ["context7", "vscode", "firecrawl", "cursor", "codex"],
+                current_dir,
+            )
+
+            self.assertTrue((current_dir / ".cursorrules").exists())
+            self.assertTrue((current_dir / "INSTRUCTIONS.md").exists())
+            self.assertFalse((current_dir / "CLAUDE.md").exists())
+            self.assertFalse(
+                (current_dir / ".agent" / "rules" / "constitution.md").exists()
+            )
+
+    def test_adapter_activation_keeps_backup_behavior(self):
+        with workspace_tempdir() as tmp:
+            current_dir = Path(tmp)
+            target = current_dir / ".cursorrules"
+            target.write_text("old", encoding="utf-8")
+
+            generate_quietly(generate_cursor_rules, "new", current_dir)
+
+            backups = list(current_dir.glob(".cursorrules.*.bak"))
+            self.assertEqual(len(backups), 1)
+            self.assertEqual(backups[0].read_text(encoding="utf-8"), "old")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This PR implements issue #7 for Rapid OS v2.

## What changed
- introduced a formal agent adapter architecture
- added an agent registry
- migrated Cursor, Claude, Antigravity, and VS Code generation into adapters
- preserved current config shape and generated file behavior
- kept compatibility wrappers for existing imports
- added tests for adapter selection, rendering, and backup behavior

## Compatibility
- no user-facing command names changed
- existing tool ids remain the same
- generated file paths remain the same
- legacy helper imports still work

## Follow-up
Next issue: #8 Add first-class Codex support to Rapid OS v2