### PR TITLE
Rapid OS v2: first-class Codex support

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Este proyecto está construido utilizando tecnologías nativas para asegurar má
 - **🧰 Gestor de Skills Híbrido**: Instala capacidades activas para tu IA desde dos fuentes:
   - _Remoto_: Acceso directo al ecosistema de la comunidad (`npx skills`) para instalar miles de herramientas.
   - _Local_: Usa tus propios templates privados (`templates/skills`) para estandarizar flujos de tu equipo.
-- **🤖 Multi-Agente Modular**: No más ruido. Elige exactamente qué archivos de configuración generar: Cursor (`.cursorrules`), Claude Code (`CLAUDE.md`), Google Antigravity (`.agent/rules`) o VS Code. La generación usa adaptadores internos para mantener cada agente aislado y listo para crecer sin cambiar tus comandos.
+- **🤖 Multi-Agente Modular**: No más ruido. Elige exactamente qué archivos de configuración generar: Cursor (`.cursorrules`), Claude Code (`CLAUDE.md`), Google Antigravity (`.agent/rules`), VS Code (`INSTRUCTIONS.md`) o Codex (`AGENTS.md`). La generación usa adaptadores internos para mantener cada agente aislado y listo para crecer sin cambiar tus comandos.
 - **🧠 Contexto de Negocio Inteligente**: Importa tus reglas de negocio desde archivos Markdown (`.md`) existentes o guárdalas como Plantillas reutilizables para futuros proyectos.
 - **🏗️ Topologías Arquitectónicas**: Define si tu proyecto es Frontend Only, BaaS (Supabase), Fullstack Separado o **Sitio de Documentación** para evitar alucinaciones de código.
 - **🔌 Herramientas MCP (Model Context Protocol)**: Configura automáticamente servidores de base de datos (Postgres/Supabase) y herramientas de investigación (Context7, Firecrawl).

--- a/docs/architecture/rapid-os-v2.md
+++ b/docs/architecture/rapid-os-v2.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Issue #6 started the Rapid OS v2 migration with extraction, not a rewrite. Issue #7 adds the first formal adapter boundary for generated agent context files while keeping the same CLI commands, project config, and generated file outputs.
+Issue #6 started the Rapid OS v2 migration with extraction, not a rewrite. Issue #7 added the first formal adapter boundary for generated agent context files while keeping the same CLI commands, project config, and generated file outputs. Issue #8 adds first-class Codex support as an opt-in adapter.
 
 `rapid.py` remains the compatibility entrypoint because the existing install scripts and user aliases execute it directly. It now delegates to the package CLI and re-exports compatibility constants/functions for existing import users.
 
@@ -15,7 +15,7 @@ Issue #6 started the Rapid OS v2 migration with extraction, not a rewrite. Issue
 - `rapid_os.core.context` composes standards and visual context in the existing priority order.
 - `rapid_os.core.output` contains shared CLI output helpers.
 - `rapid_os.domain.agents` is now a compatibility facade for the existing generation helpers.
-- `rapid_os.adapters.agents` owns the agent adapter contract, default registry, and implementations for Cursor, Claude, Antigravity, and VS Code.
+- `rapid_os.adapters.agents` owns the agent adapter contract, default registry, and implementations for Cursor, Claude, Antigravity, VS Code, and Codex.
 
 The package modules avoid command execution on import. Console UTF-8 setup happens when the CLI entrypoint runs, so importing reusable helpers remains lightweight for tests and future integrations.
 
@@ -29,14 +29,17 @@ Agent-specific project context generation now flows through `AgentAdapter` imple
 - Activation and placement behavior through the base `activate()` flow, including parent directory creation, backup creation, UTF-8 writes, and the existing success messages.
 - Optional metadata for user-facing or future orchestration needs.
 
-The default registry preserves the previous generation order: Cursor, Claude, Antigravity, then VS Code. Unknown tool ids remain ignored during context generation, which keeps research tool config entries such as `context7` and `firecrawl` compatible with the existing project config shape.
+The default registry preserves the previous generation order for existing agents: Cursor, Claude, Antigravity, then VS Code. Codex is registered after those adapters. Unknown tool ids remain ignored during context generation, which keeps research tool config entries such as `context7` and `firecrawl` compatible with the existing project config shape.
 
-Supported adapters in issue #7:
+Supported adapters after issue #8:
 
 - Cursor: `.cursorrules`
 - Claude Code: `CLAUDE.md`
 - Google Antigravity: `.agent/rules/constitution.md`
 - VS Code / Copilot: `INSTRUCTIONS.md`
+- Codex: `AGENTS.md`
+
+Codex support is project-scoped and opt-in. Selecting `codex` writes `AGENTS.md` at the project root with the composed Rapid OS context. Rapid OS does not generate `AGENTS.override.md`, global Codex configuration, or nested Codex instruction files in this migration step.
 
 ## Compatibility Guarantees
 
@@ -44,18 +47,19 @@ Supported adapters in issue #7:
 - Existing aliases that call `python rapid.py` continue to work.
 - Existing import users can still read common compatibility constants from `rapid.py`, including `SCRIPT_DIR`, `TEMPLATES_DIR`, `CURRENT_DIR`, `PROJECT_RAPID_DIR`, and `CONFIG_FILE`.
 - Existing import users can still call `generate_cursor_rules`, `generate_claude_config`, `generate_antigravity_config`, and `generate_vscode_instructions`; those helpers now delegate to adapters.
-- Generated files remain in their current locations: `.cursorrules`, `CLAUDE.md`, `.agent/rules/constitution.md`, `INSTRUCTIONS.md`, `claude_desktop_config.json`, `SPECS.md`, `DEPLOY.md`, and `references/VISION_CONTEXT.md`.
+- Generated files remain in their current locations: `.cursorrules`, `CLAUDE.md`, `.agent/rules/constitution.md`, `INSTRUCTIONS.md`, `AGENTS.md`, `claude_desktop_config.json`, `SPECS.md`, `DEPLOY.md`, and `references/VISION_CONTEXT.md`.
 - Project config remains `.rapid-os/config.json`.
+- Missing project config still defaults to Cursor, Claude, Antigravity, and VS Code only; Codex must be explicitly selected or added to `tools`.
 - Template discovery still prefers a source checkout `templates/` directory and falls back to `~/.rapid-os/templates`.
 
 ## Intentionally Unchanged
 
-This PR does not introduce first-class Codex support, redesign MCP generation, redesign scope/spec workflows, add validation commands, or change install scripts.
+This migration does not redesign MCP generation, redesign scope/spec workflows, add validation commands, change install scripts, generate global Codex config, or add `AGENTS.override.md`.
 
 Some command workflows still live in `rapid_os.cli.main` because moving them wholesale into new abstractions would be a larger behavior-changing rewrite. The priority here is to isolate reusable logic first, then migrate command domains incrementally.
 
 ## Remaining Migration Work
 
-Issue #8 should add first-class Codex support behind the same adapter contract. That work should define Codex output files, activation semantics, skill placement expectations, and any metadata needed by the CLI before adding `codex` to default project configuration.
+Future Codex work can add Codex-specific skill placement, deeper Codex configuration, validation helpers, or nested instruction-file support. Those additions should remain behind the adapter boundary and be introduced in separate PRs.
 
-After Codex is added, command flows can be split further by domain once the adapter boundary is stable.
+Command flows can be split further by domain once the adapter boundary is stable.

--- a/rapid_os/adapters/agents/implementations.py
+++ b/rapid_os/adapters/agents/implementations.py
@@ -80,9 +80,32 @@ class VSCodeAdapter(AgentAdapter):
         }
 
 
+class CodexAdapter(AgentAdapter):
+    id = "codex"
+    name = "Codex"
+    metadata = {
+        "activation": "Project root AGENTS.md",
+        "scope": "repository",
+        "agent": "Codex",
+    }
+    outputs = (
+        AgentOutput(Path("AGENTS.md"), "Generado: AGENTS.md"),
+    )
+
+    def render(self, context: str) -> Mapping[Path, str]:
+        return {
+            Path("AGENTS.md"): (
+                "# RAPID OS - CODEX PROJECT INSTRUCTIONS\n"
+                "# SOURCE OF TRUTH FOR CODEX.\n\n"
+                f"{context}"
+            )
+        }
+
+
 SUPPORTED_AGENT_ADAPTERS = (
     CursorAdapter,
     ClaudeAdapter,
     AntigravityAdapter,
     VSCodeAdapter,
+    CodexAdapter,
 )

--- a/rapid_os/cli/main.py
+++ b/rapid_os/cli/main.py
@@ -25,6 +25,25 @@ from rapid_os.core.paths import (
 from rapid_os.domain.agents import generate_agent_contexts
 
 
+def parse_agent_selection(agent_sel):
+    selected_tools = []
+    if not agent_sel or not agent_sel.strip():
+        return ["cursor"]
+
+    parts = [part.strip() for part in agent_sel.split(",")]
+    if "1" in parts:
+        selected_tools.append("cursor")
+    if "2" in parts:
+        selected_tools.append("claude")
+    if "3" in parts:
+        selected_tools.append("antigravity")
+    if "4" in parts:
+        selected_tools.append("vscode")
+    if "5" in parts:
+        selected_tools.append("codex")
+    return selected_tools
+
+
 def regenerate_context():
     """Compila estándares y genera SOLO para las herramientas seleccionadas."""
     full_context = compose_project_context(PROJECT_RAPID_DIR, CURRENT_DIR)
@@ -100,20 +119,9 @@ def init_project(args):
     print(" 2) Claude Code (CLAUDE.md)")
     print(" 3) Google Antigravity (.agent/rules)")
     print(" 4) VS Code / Copilot (INSTRUCTIONS.md)")
+    print(" 5) Codex (AGENTS.md)")
     agent_sel = input("Opción [1]: ").strip()
-    selected_tools = []
-    if not agent_sel:
-        selected_tools = ["cursor"]
-    else:
-        parts = agent_sel.split(",")
-        if "1" in parts:
-            selected_tools.append("cursor")
-        if "2" in parts:
-            selected_tools.append("claude")
-        if "3" in parts:
-            selected_tools.append("antigravity")
-        if "4" in parts:
-            selected_tools.append("vscode")
+    selected_tools = parse_agent_selection(agent_sel)
 
     # 5. Herramientas de Investigación (Research)
     print("\n🔍 CAPACIDADES DE INVESTIGACIÓN (Opcional):")

--- a/tests/test_agent_adapters.py
+++ b/tests/test_agent_adapters.py
@@ -32,7 +32,7 @@ class AgentAdapterTests(unittest.TestCase):
 
         self.assertEqual(
             registry.ids(),
-            ("cursor", "claude", "antigravity", "vscode"),
+            ("cursor", "claude", "antigravity", "vscode", "codex"),
         )
 
     def test_adapters_declare_output_files_and_metadata(self):
@@ -52,7 +52,15 @@ class AgentAdapterTests(unittest.TestCase):
             DEFAULT_AGENT_REGISTRY.get("vscode").output_files,
             (Path("INSTRUCTIONS.md"),),
         )
+        self.assertEqual(
+            DEFAULT_AGENT_REGISTRY.get("codex").output_files,
+            (Path("AGENTS.md"),),
+        )
         self.assertIn("activation", DEFAULT_AGENT_REGISTRY.get("cursor").metadata)
+        self.assertEqual(
+            DEFAULT_AGENT_REGISTRY.get("codex").metadata["scope"],
+            "repository",
+        )
 
     def test_legacy_wrappers_render_existing_file_contents(self):
         with workspace_tempdir() as tmp:
@@ -98,7 +106,7 @@ class AgentAdapterTests(unittest.TestCase):
             generate_quietly(
                 generate_agent_contexts,
                 "project context",
-                ["context7", "vscode", "firecrawl", "cursor", "codex"],
+                ["context7", "vscode", "firecrawl", "cursor", "unknown-agent"],
                 current_dir,
             )
 
@@ -108,6 +116,45 @@ class AgentAdapterTests(unittest.TestCase):
             self.assertFalse(
                 (current_dir / ".agent" / "rules" / "constitution.md").exists()
             )
+            self.assertFalse((current_dir / "AGENTS.md").exists())
+
+    def test_codex_adapter_renders_exact_agents_md_content(self):
+        codex = DEFAULT_AGENT_REGISTRY.get("codex")
+
+        self.assertEqual(
+            codex.render("project context"),
+            {
+                Path("AGENTS.md"): (
+                    "# RAPID OS - CODEX PROJECT INSTRUCTIONS\n"
+                    "# SOURCE OF TRUTH FOR CODEX.\n\n"
+                    "project context"
+                )
+            },
+        )
+
+    def test_generate_agent_contexts_writes_codex_agents_md_when_selected(self):
+        with workspace_tempdir() as tmp:
+            current_dir = Path(tmp)
+
+            generate_quietly(
+                generate_agent_contexts,
+                "project context",
+                ["codex"],
+                current_dir,
+            )
+
+            self.assertEqual(
+                (current_dir / "AGENTS.md").read_text(encoding="utf-8"),
+                "# RAPID OS - CODEX PROJECT INSTRUCTIONS\n"
+                "# SOURCE OF TRUTH FOR CODEX.\n\n"
+                "project context",
+            )
+            self.assertFalse((current_dir / ".cursorrules").exists())
+            self.assertFalse((current_dir / "CLAUDE.md").exists())
+            self.assertFalse(
+                (current_dir / ".agent" / "rules" / "constitution.md").exists()
+            )
+            self.assertFalse((current_dir / "INSTRUCTIONS.md").exists())
 
     def test_adapter_activation_keeps_backup_behavior(self):
         with workspace_tempdir() as tmp:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ import sys
 import unittest
 from pathlib import Path
 
-from rapid_os.cli.main import create_parser
+from rapid_os.cli.main import create_parser, parse_agent_selection
 
 
 class CliSmokeTests(unittest.TestCase):
@@ -30,6 +30,16 @@ class CliSmokeTests(unittest.TestCase):
                 "prompt",
                 "guide",
             },
+        )
+
+    def test_agent_selection_default_remains_cursor_only(self):
+        self.assertEqual(parse_agent_selection(""), ["cursor"])
+        self.assertEqual(parse_agent_selection("   "), ["cursor"])
+
+    def test_agent_selection_includes_codex_when_explicitly_selected(self):
+        self.assertEqual(
+            parse_agent_selection("1, 5"),
+            ["cursor", "codex"],
         )
 
     def test_rapid_help_smoke(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,11 +17,13 @@ class ProjectConfigTests(unittest.TestCase):
     def test_missing_config_returns_current_defaults(self):
         with workspace_tempdir() as tmp:
             config_file = Path(tmp) / ".rapid-os" / "config.json"
+            config = load_project_config(config_file)
 
             self.assertEqual(
-                load_project_config(config_file),
+                config,
                 {"tools": ["cursor", "claude", "antigravity", "vscode"]},
             )
+            self.assertNotIn("codex", config["tools"])
 
     def test_valid_config_loads(self):
         with workspace_tempdir() as tmp:


### PR DESCRIPTION
## Summary
This PR implements issue #8 for Rapid OS v2.

## What changed
- added Codex as a first-class supported agent
- introduced a Codex adapter using the existing adapter architecture
- registered Codex in the agent registry
- added AGENTS.md generation at the project root
- added Codex as an explicit option in rapid init
- added tests and docs

## Compatibility
- existing commands remain unchanged
- existing agents continue to work unchanged
- project config shape remains the same
- Codex support is opt-in in this PR
- Codex was intentionally not added to DEFAULT_PROJECT_CONFIG

## Follow-up
Future improvements may include richer Codex-specific project instructions, nested AGENTS.md handling, or additional Codex workflow integrations