### PR TITLE
Rapid OS v2: upgrade scope into structured spec generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Este proyecto está construido utilizando tecnologías nativas para asegurar má
 - **🧰 Gestor de Skills Híbrido**: Instala capacidades activas para tu IA desde dos fuentes:
   - _Remoto_: Acceso directo al ecosistema de la comunidad (`npx skills`) para instalar miles de herramientas.
   - _Local_: Usa tus propios templates privados (`templates/skills`) para estandarizar flujos de tu equipo.
-- **🤖 Multi-Agente Modular**: No más ruido. Elige exactamente qué archivos de configuración generar: Cursor (`.cursorrules`), Claude Code (`CLAUDE.md`), Google Antigravity (`.agent/rules`) o VS Code. La generación usa adaptadores internos para mantener cada agente aislado y listo para crecer sin cambiar tus comandos.
+- **🤖 Multi-Agente Modular**: No más ruido. Elige exactamente qué archivos de configuración generar: Cursor (`.cursorrules`), Claude Code (`CLAUDE.md`), Google Antigravity (`.agent/rules`), VS Code (`INSTRUCTIONS.md`) o Codex (`AGENTS.md`). La generación usa adaptadores internos para mantener cada agente aislado y listo para crecer sin cambiar tus comandos.
 - **🧠 Contexto de Negocio Inteligente**: Importa tus reglas de negocio desde archivos Markdown (`.md`) existentes o guárdalas como Plantillas reutilizables para futuros proyectos.
 - **🏗️ Topologías Arquitectónicas**: Define si tu proyecto es Frontend Only, BaaS (Supabase), Fullstack Separado o **Sitio de Documentación** para evitar alucinaciones de código.
 - **🔌 Herramientas MCP (Model Context Protocol)**: Configura automáticamente servidores de base de datos (Postgres/Supabase) y herramientas de investigación (Context7, Firecrawl).

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ graph TD
         User -->|2a. Define funcionalidad| ScopeCmd
         User -->|2b. Instala Skills| SkillCmd
 
-        SpecsFile[📄 SPECS.md <br> Instrucciones Funcionales]:::context
+        SpecsFile[📄 SPECS.md / TASKS.md / ACCEPTANCE.md <br> Plan de Implementación]:::context
         SkillsFolder[📂 Skills Activas <br> .cursor/skills]:::context
 
         ScopeCmd --> SpecsFile
@@ -244,9 +244,10 @@ Evita darle instrucciones vagas a la IA como _"Mejora el código"_. Usa el **Asi
 rapid scope
 ```
 
-- Responde las preguntas: **Nombre**, **Objetivo** y **Flujo**.
-- Rapid OS generará un archivo `SPECS.md` optimizado para LLMs.
-- **Tu Prompt Final**: _"Implementa el plan detallado en SPECS.md paso a paso."_
+- Selecciona el modo: **new feature**, **refactor**, **bugfix** o **legacy hardening**.
+- Responde preguntas de negocio, alcance, actores, flujo, casos borde, reglas, restricciones, impacto en datos, criterios de aceptación, pruebas y tareas.
+- Rapid OS generará `SPECS.md`, `TASKS.md` y `ACCEPTANCE.md` optimizados para implementación guiada por specs.
+- **Tu Prompt Final**: _"Implementa el plan detallado en SPECS.md paso a paso y valida contra ACCEPTANCE.md."_
 
 ### 5. Configurar Herramientas de Base de Datos (MCP)
 
@@ -327,7 +328,7 @@ Tabla completa de comandos disponibles en Rapid OS y sus resultados.
 | Comando                      | Descripción                                                                                     | Resultado / Output                                                                                |
 | :--------------------------- | :---------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------ |
 | `rapid init`                 | **Inicializa Rapid OS** en el directorio actual. Detecta stack y crea archivos de contexto.     | Crea `.cursorrules`, `.agent/rules`, `.rapid-os/` y backups de config existente.                  |
-| `rapid scope`                | **Asistente de Alcance**. Te entrevista para definir una nueva funcionalidad o refactorización. | Genera `SPECS.md` con un plan paso-a-paso optimizado para que la IA lo ejecute.                   |
+| `rapid scope`                | **Asistente de Alcance**. Te entrevista para definir una feature, refactor, bugfix o hardening. | Genera `SPECS.md`, `TASKS.md` y `ACCEPTANCE.md` con backups antes de sobrescribir.                |
 | `rapid refine <file>`        | **Refinamiento de Reglas**. Mejora cualquier documento de reglas usando IA.                     | Genera un Mega-Prompt para que pegues en tu chat y la IA reescriba el archivo profesionalmente.   |
 | `rapid skill add <name>`     | **Instala una Skill** desde el registro comunitario.                                            | Descarga la skill en `.cursor/skills/<name>` y la activa en el contexto.                          |
 | `rapid skill install <path>` | **Instala una Skill Local** desde una carpeta o template privado.                               | Copia la skill local a la carpeta de skills activas del proyecto.                                 |
@@ -357,8 +358,9 @@ Lo que Rapid OS **ES** y lo que **NO ES**:
 1.  **Inyección**: Entras a la carpeta y ejecutas `rapid init`. Seleccionas "Web Moderno" (Force Functional Components).
 2.  **Scope**: Ejecutas `rapid scope`.
     - _Nombre_: "Migración Auth a Context"
+    - _Modo_: "refactor"
     - _Objetivo_: "Eliminar Redux de /auth y usar React Context."
-    - _Flujo_: "1. Crear AuthContext. 2. Migrar Login.js. 3. Eliminar reducers."
+    - _Tareas_: "Crear AuthContext, Migrar Login.js, Eliminar reducers."
 3.  **Ejecución**:
     - Abres Cursor/Claude.
     - Escribes: _"@SPECS.md @.cursorrules Sigue el plan de refactorización. Empieza por el paso 1."_

--- a/docs/architecture/rapid-os-v2.md
+++ b/docs/architecture/rapid-os-v2.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Issue #6 started the Rapid OS v2 migration with extraction, not a rewrite. Issue #7 adds the first formal adapter boundary for generated agent context files while keeping the same CLI commands, project config, and generated file outputs.
+Issue #6 started the Rapid OS v2 migration with extraction, not a rewrite. Issue #7 added the first formal adapter boundary for generated agent context files while keeping the same CLI commands, project config, and generated file outputs. Issue #8 adds first-class Codex support as an opt-in adapter.
 
 `rapid.py` remains the compatibility entrypoint because the existing install scripts and user aliases execute it directly. It now delegates to the package CLI and re-exports compatibility constants/functions for existing import users.
 
@@ -15,7 +15,7 @@ Issue #6 started the Rapid OS v2 migration with extraction, not a rewrite. Issue
 - `rapid_os.core.context` composes standards and visual context in the existing priority order.
 - `rapid_os.core.output` contains shared CLI output helpers.
 - `rapid_os.domain.agents` is now a compatibility facade for the existing generation helpers.
-- `rapid_os.adapters.agents` owns the agent adapter contract, default registry, and implementations for Cursor, Claude, Antigravity, and VS Code.
+- `rapid_os.adapters.agents` owns the agent adapter contract, default registry, and implementations for Cursor, Claude, Antigravity, VS Code, and Codex.
 
 The package modules avoid command execution on import. Console UTF-8 setup happens when the CLI entrypoint runs, so importing reusable helpers remains lightweight for tests and future integrations.
 
@@ -29,14 +29,17 @@ Agent-specific project context generation now flows through `AgentAdapter` imple
 - Activation and placement behavior through the base `activate()` flow, including parent directory creation, backup creation, UTF-8 writes, and the existing success messages.
 - Optional metadata for user-facing or future orchestration needs.
 
-The default registry preserves the previous generation order: Cursor, Claude, Antigravity, then VS Code. Unknown tool ids remain ignored during context generation, which keeps research tool config entries such as `context7` and `firecrawl` compatible with the existing project config shape.
+The default registry preserves the previous generation order for existing agents: Cursor, Claude, Antigravity, then VS Code. Codex is registered after those adapters. Unknown tool ids remain ignored during context generation, which keeps research tool config entries such as `context7` and `firecrawl` compatible with the existing project config shape.
 
-Supported adapters in issue #7:
+Supported adapters after issue #8:
 
 - Cursor: `.cursorrules`
 - Claude Code: `CLAUDE.md`
 - Google Antigravity: `.agent/rules/constitution.md`
 - VS Code / Copilot: `INSTRUCTIONS.md`
+- Codex: `AGENTS.md`
+
+Codex support is project-scoped and opt-in. Selecting `codex` writes `AGENTS.md` at the project root with the composed Rapid OS context. Rapid OS does not generate `AGENTS.override.md`, global Codex configuration, or nested Codex instruction files in this migration step.
 
 ## Compatibility Guarantees
 
@@ -44,18 +47,19 @@ Supported adapters in issue #7:
 - Existing aliases that call `python rapid.py` continue to work.
 - Existing import users can still read common compatibility constants from `rapid.py`, including `SCRIPT_DIR`, `TEMPLATES_DIR`, `CURRENT_DIR`, `PROJECT_RAPID_DIR`, and `CONFIG_FILE`.
 - Existing import users can still call `generate_cursor_rules`, `generate_claude_config`, `generate_antigravity_config`, and `generate_vscode_instructions`; those helpers now delegate to adapters.
-- Generated files remain in their current locations: `.cursorrules`, `CLAUDE.md`, `.agent/rules/constitution.md`, `INSTRUCTIONS.md`, `claude_desktop_config.json`, `SPECS.md`, `DEPLOY.md`, and `references/VISION_CONTEXT.md`.
+- Generated files remain in their current locations: `.cursorrules`, `CLAUDE.md`, `.agent/rules/constitution.md`, `INSTRUCTIONS.md`, `AGENTS.md`, `claude_desktop_config.json`, `SPECS.md`, `DEPLOY.md`, and `references/VISION_CONTEXT.md`.
 - Project config remains `.rapid-os/config.json`.
+- Missing project config still defaults to Cursor, Claude, Antigravity, and VS Code only; Codex must be explicitly selected or added to `tools`.
 - Template discovery still prefers a source checkout `templates/` directory and falls back to `~/.rapid-os/templates`.
 
 ## Intentionally Unchanged
 
-This PR does not introduce first-class Codex support, redesign MCP generation, redesign scope/spec workflows, add validation commands, or change install scripts.
+This migration does not redesign MCP generation, redesign scope/spec workflows, add validation commands, change install scripts, generate global Codex config, or add `AGENTS.override.md`.
 
 Some command workflows still live in `rapid_os.cli.main` because moving them wholesale into new abstractions would be a larger behavior-changing rewrite. The priority here is to isolate reusable logic first, then migrate command domains incrementally.
 
 ## Remaining Migration Work
 
-Issue #8 should add first-class Codex support behind the same adapter contract. That work should define Codex output files, activation semantics, skill placement expectations, and any metadata needed by the CLI before adding `codex` to default project configuration.
+Future Codex work can add Codex-specific skill placement, deeper Codex configuration, validation helpers, or nested instruction-file support. Those additions should remain behind the adapter boundary and be introduced in separate PRs.
 
-After Codex is added, command flows can be split further by domain once the adapter boundary is stable.
+Command flows can be split further by domain once the adapter boundary is stable.

--- a/docs/architecture/rapid-os-v2.md
+++ b/docs/architecture/rapid-os-v2.md
@@ -15,6 +15,7 @@ Issue #6 started the Rapid OS v2 migration with extraction, not a rewrite. Issue
 - `rapid_os.core.context` composes standards and visual context in the existing priority order.
 - `rapid_os.core.output` contains shared CLI output helpers.
 - `rapid_os.domain.agents` is now a compatibility facade for the existing generation helpers.
+- `rapid_os.domain.scope` renders and writes structured spec-driven development artifacts for `rapid scope`.
 - `rapid_os.adapters.agents` owns the agent adapter contract, default registry, and implementations for Cursor, Claude, Antigravity, VS Code, and Codex.
 
 The package modules avoid command execution on import. Console UTF-8 setup happens when the CLI entrypoint runs, so importing reusable helpers remains lightweight for tests and future integrations.
@@ -41,25 +42,33 @@ Supported adapters after issue #8:
 
 Codex support is project-scoped and opt-in. Selecting `codex` writes `AGENTS.md` at the project root with the composed Rapid OS context. Rapid OS does not generate `AGENTS.override.md`, global Codex configuration, or nested Codex instruction files in this migration step.
 
+## Scope Artifact Workflow
+
+Issue #10 upgrades `rapid scope` from a minimal one-file prompt helper into a structured spec generator. The command remains interactive and keeps `SPECS.md` as the primary artifact, while also writing `TASKS.md` and `ACCEPTANCE.md`.
+
+The scope workflow collects initiative details, mode, business objective, problem statement, scope boundaries, actors, main flow, edge cases, business rules, technical constraints, affected modules, data impact, acceptance criteria, testing strategy, and implementation tasks. Supported modes are `new feature`, `refactor`, `bugfix`, and `legacy hardening`.
+
+Scope rendering is deterministic and local. Rapid OS does not infer tasks or acceptance criteria with AI in this workflow. Blank fields are rendered as `_Not specified._`, and comma- or semicolon-separated answers become Markdown lists or checklists. Existing `SPECS.md`, `TASKS.md`, and `ACCEPTANCE.md` files are backed up before being overwritten.
+
 ## Compatibility Guarantees
 
 - Existing commands remain available: `init`, `skill`, `mcp`, `scope`, `deploy`, `vision`, `refine`, `guide`, and the current `prompt` command.
 - Existing aliases that call `python rapid.py` continue to work.
 - Existing import users can still read common compatibility constants from `rapid.py`, including `SCRIPT_DIR`, `TEMPLATES_DIR`, `CURRENT_DIR`, `PROJECT_RAPID_DIR`, and `CONFIG_FILE`.
 - Existing import users can still call `generate_cursor_rules`, `generate_claude_config`, `generate_antigravity_config`, and `generate_vscode_instructions`; those helpers now delegate to adapters.
-- Generated files remain in their current locations: `.cursorrules`, `CLAUDE.md`, `.agent/rules/constitution.md`, `INSTRUCTIONS.md`, `AGENTS.md`, `claude_desktop_config.json`, `SPECS.md`, `DEPLOY.md`, and `references/VISION_CONTEXT.md`.
+- Generated files remain in their current locations: `.cursorrules`, `CLAUDE.md`, `.agent/rules/constitution.md`, `INSTRUCTIONS.md`, `AGENTS.md`, `claude_desktop_config.json`, `SPECS.md`, `TASKS.md`, `ACCEPTANCE.md`, `DEPLOY.md`, and `references/VISION_CONTEXT.md`.
 - Project config remains `.rapid-os/config.json`.
 - Missing project config still defaults to Cursor, Claude, Antigravity, and VS Code only; Codex must be explicitly selected or added to `tools`.
 - Template discovery still prefers a source checkout `templates/` directory and falls back to `~/.rapid-os/templates`.
 
 ## Intentionally Unchanged
 
-This migration does not redesign MCP generation, redesign scope/spec workflows, add validation commands, change install scripts, generate global Codex config, or add `AGENTS.override.md`.
+This migration does not redesign MCP generation, add validation commands, change install scripts, generate global Codex config, or add `AGENTS.override.md`.
 
 Some command workflows still live in `rapid_os.cli.main` because moving them wholesale into new abstractions would be a larger behavior-changing rewrite. The priority here is to isolate reusable logic first, then migrate command domains incrementally.
 
 ## Remaining Migration Work
 
-Future Codex work can add Codex-specific skill placement, deeper Codex configuration, validation helpers, or nested instruction-file support. Those additions should remain behind the adapter boundary and be introduced in separate PRs.
+Future Codex work can add Codex-specific skill placement, deeper Codex configuration, validation helpers, or nested instruction-file support. Future scope work can add non-interactive flags, richer templates, or validation. Those additions should remain behind the existing boundaries and be introduced in separate PRs.
 
 Command flows can be split further by domain once the adapter boundary is stable.

--- a/rapid_os/adapters/agents/implementations.py
+++ b/rapid_os/adapters/agents/implementations.py
@@ -80,9 +80,32 @@ class VSCodeAdapter(AgentAdapter):
         }
 
 
+class CodexAdapter(AgentAdapter):
+    id = "codex"
+    name = "Codex"
+    metadata = {
+        "activation": "Project root AGENTS.md",
+        "scope": "repository",
+        "agent": "Codex",
+    }
+    outputs = (
+        AgentOutput(Path("AGENTS.md"), "Generado: AGENTS.md"),
+    )
+
+    def render(self, context: str) -> Mapping[Path, str]:
+        return {
+            Path("AGENTS.md"): (
+                "# RAPID OS - CODEX PROJECT INSTRUCTIONS\n"
+                "# SOURCE OF TRUTH FOR CODEX.\n\n"
+                f"{context}"
+            )
+        }
+
+
 SUPPORTED_AGENT_ADAPTERS = (
     CursorAdapter,
     ClaudeAdapter,
     AntigravityAdapter,
     VSCodeAdapter,
+    CodexAdapter,
 )

--- a/rapid_os/cli/main.py
+++ b/rapid_os/cli/main.py
@@ -23,6 +23,12 @@ from rapid_os.core.paths import (
     TEMPLATES_DIR,
 )
 from rapid_os.domain.agents import generate_agent_contexts
+from rapid_os.domain.scope import (
+    ScopeSpec,
+    normalize_mode,
+    parse_list,
+    write_scope_artifacts,
+)
 
 
 def parse_agent_selection(agent_sel):
@@ -363,12 +369,36 @@ def generate_mcp_config(args):
 
 def scope_feature(args):
     print("\n🔭 SCOPE WIZARD")
-    name = input("Nombre funcionalidad: ").strip()
-    goal = input("Objetivo: ").strip()
-    flow = input("Flujo: ").strip()
-    content = f"# SPEC: {name.upper()}\n\n## GOAL\n{goal}\n\n## FLOW\n{flow}"
-    (CURRENT_DIR / "SPECS.md").write_text(content, encoding="utf-8")
-    print_success("SPECS.md creado")
+    print("Modo:")
+    print(" 1) new feature")
+    print(" 2) refactor")
+    print(" 3) bugfix")
+    print(" 4) legacy hardening")
+    print("Tip: usa comas o punto y coma para respuestas tipo lista.")
+
+    spec = ScopeSpec(
+        initiative_name=input("Nombre iniciativa: ").strip(),
+        mode=normalize_mode(input("Modo [1]: ").strip()),
+        business_objective=input("Objetivo de negocio: ").strip(),
+        problem_statement=input("Problema a resolver: ").strip(),
+        scope=parse_list(input("Alcance: ").strip()),
+        out_of_scope=parse_list(input("Fuera de alcance: ").strip()),
+        actors_users=parse_list(input("Actores/usuarios: ").strip()),
+        main_flow=parse_list(input("Flujo principal: ").strip()),
+        edge_cases=parse_list(input("Casos borde: ").strip()),
+        business_rules=parse_list(input("Reglas de negocio: ").strip()),
+        technical_constraints=parse_list(input("Restricciones técnicas: ").strip()),
+        affected_files_modules=parse_list(
+            input("Archivos/módulos afectados si se conocen: ").strip()
+        ),
+        data_impact=input("Impacto en datos: ").strip(),
+        acceptance_criteria=parse_list(input("Criterios de aceptación: ").strip()),
+        testing_strategy=parse_list(input("Estrategia de pruebas: ").strip()),
+        implementation_tasks=parse_list(input("Tareas de implementación: ").strip()),
+    )
+
+    for target in write_scope_artifacts(spec, CURRENT_DIR):
+        print_success(f"{target.name} creado")
 
 
 def deploy_assistant(args):

--- a/rapid_os/cli/main.py
+++ b/rapid_os/cli/main.py
@@ -25,6 +25,25 @@ from rapid_os.core.paths import (
 from rapid_os.domain.agents import generate_agent_contexts
 
 
+def parse_agent_selection(agent_sel):
+    selected_tools = []
+    if not agent_sel or not agent_sel.strip():
+        return ["cursor"]
+
+    parts = [part.strip() for part in agent_sel.split(",")]
+    if "1" in parts:
+        selected_tools.append("cursor")
+    if "2" in parts:
+        selected_tools.append("claude")
+    if "3" in parts:
+        selected_tools.append("antigravity")
+    if "4" in parts:
+        selected_tools.append("vscode")
+    if "5" in parts:
+        selected_tools.append("codex")
+    return selected_tools
+
+
 def regenerate_context():
     """Compila estándares y genera SOLO para las herramientas seleccionadas."""
     full_context = compose_project_context(PROJECT_RAPID_DIR, CURRENT_DIR)
@@ -100,20 +119,9 @@ def init_project(args):
     print(" 2) Claude Code (CLAUDE.md)")
     print(" 3) Google Antigravity (.agent/rules)")
     print(" 4) VS Code / Copilot (INSTRUCTIONS.md)")
+    print(" 5) Codex (AGENTS.md)")
     agent_sel = input("Opción [1]: ").strip()
-    selected_tools = []
-    if not agent_sel:
-        selected_tools = ["cursor"]
-    else:
-        parts = agent_sel.split(",")
-        if "1" in parts:
-            selected_tools.append("cursor")
-        if "2" in parts:
-            selected_tools.append("claude")
-        if "3" in parts:
-            selected_tools.append("antigravity")
-        if "4" in parts:
-            selected_tools.append("vscode")
+    selected_tools = parse_agent_selection(agent_sel)
 
     # 5. Herramientas de Investigación (Research)
     print("\n🔍 CAPACIDADES DE INVESTIGACIÓN (Opcional):")

--- a/rapid_os/domain/scope.py
+++ b/rapid_os/domain/scope.py
@@ -1,0 +1,140 @@
+from dataclasses import dataclass
+from pathlib import Path
+from re import split
+
+from rapid_os.core.filesystem import create_backup
+
+
+NOT_SPECIFIED = "_Not specified._"
+SUPPORTED_MODES = ("new feature", "refactor", "bugfix", "legacy hardening")
+MODE_ALIASES = {
+    "1": "new feature",
+    "feature": "new feature",
+    "new": "new feature",
+    "new feature": "new feature",
+    "2": "refactor",
+    "refactor": "refactor",
+    "refactoring": "refactor",
+    "3": "bugfix",
+    "bug": "bugfix",
+    "bugfix": "bugfix",
+    "fix": "bugfix",
+    "4": "legacy hardening",
+    "hardening": "legacy hardening",
+    "legacy": "legacy hardening",
+    "legacy hardening": "legacy hardening",
+}
+
+
+@dataclass(frozen=True)
+class ScopeSpec:
+    initiative_name: str
+    mode: str
+    business_objective: str
+    problem_statement: str
+    scope: list[str]
+    out_of_scope: list[str]
+    actors_users: list[str]
+    main_flow: list[str]
+    edge_cases: list[str]
+    business_rules: list[str]
+    technical_constraints: list[str]
+    affected_files_modules: list[str]
+    data_impact: str
+    acceptance_criteria: list[str]
+    testing_strategy: list[str]
+    implementation_tasks: list[str]
+
+
+def normalize_mode(mode):
+    normalized = (mode or "").strip().lower()
+    return MODE_ALIASES.get(normalized, "new feature")
+
+
+def normalize_text(value):
+    normalized = (value or "").strip()
+    return normalized if normalized else NOT_SPECIFIED
+
+
+def parse_list(value):
+    if not value or not value.strip():
+        return []
+    return [item.strip() for item in split(r"[;,]", value) if item.strip()]
+
+
+def render_text(value):
+    return normalize_text(value)
+
+
+def render_bullets(items):
+    normalized_items = [item.strip() for item in items if item and item.strip()]
+    if not normalized_items:
+        return NOT_SPECIFIED
+    return "\n".join(f"- {item}" for item in normalized_items)
+
+
+def render_checklist(items):
+    normalized_items = [item.strip() for item in items if item and item.strip()]
+    if not normalized_items:
+        return NOT_SPECIFIED
+    return "\n".join(f"- [ ] {item}" for item in normalized_items)
+
+
+def render_specs(spec):
+    return (
+        f"# SPEC: {render_text(spec.initiative_name)}\n\n"
+        f"## Mode\n{render_text(spec.mode)}\n\n"
+        f"## Business Objective\n{render_text(spec.business_objective)}\n\n"
+        f"## Problem Statement\n{render_text(spec.problem_statement)}\n\n"
+        f"## Scope\n{render_bullets(spec.scope)}\n\n"
+        f"## Out of Scope\n{render_bullets(spec.out_of_scope)}\n\n"
+        f"## Actors / Users\n{render_bullets(spec.actors_users)}\n\n"
+        f"## Main Flow\n{render_bullets(spec.main_flow)}\n\n"
+        f"## Edge Cases\n{render_bullets(spec.edge_cases)}\n\n"
+        f"## Business Rules\n{render_bullets(spec.business_rules)}\n\n"
+        f"## Technical Constraints\n{render_bullets(spec.technical_constraints)}\n\n"
+        f"## Affected Files / Modules\n{render_bullets(spec.affected_files_modules)}\n\n"
+        f"## Data Impact\n{render_text(spec.data_impact)}"
+    )
+
+
+def render_tasks(spec):
+    return (
+        f"# TASKS: {render_text(spec.initiative_name)}\n\n"
+        f"## Implementation Tasks\n{render_checklist(spec.implementation_tasks)}\n\n"
+        "## Execution Notes\n"
+        "- Work from `SPECS.md` as the source of scope.\n"
+        "- Validate each task against `ACCEPTANCE.md`.\n"
+        "- Keep implementation changes inside the documented scope."
+    )
+
+
+def render_acceptance(spec):
+    return (
+        f"# ACCEPTANCE: {render_text(spec.initiative_name)}\n\n"
+        f"## Acceptance Criteria\n{render_checklist(spec.acceptance_criteria)}\n\n"
+        f"## Testing Strategy\n{render_bullets(spec.testing_strategy)}\n\n"
+        "## Definition of Done\n"
+        "- [ ] Acceptance criteria reviewed\n"
+        "- [ ] Testing strategy completed or explicitly deferred\n"
+        "- [ ] Implementation matches `SPECS.md`\n"
+        "- [ ] Tasks in `TASKS.md` are complete or intentionally deferred"
+    )
+
+
+def render_scope_artifacts(spec):
+    return {
+        "SPECS.md": render_specs(spec),
+        "TASKS.md": render_tasks(spec),
+        "ACCEPTANCE.md": render_acceptance(spec),
+    }
+
+
+def write_scope_artifacts(spec, current_dir):
+    written = []
+    for filename, content in render_scope_artifacts(spec).items():
+        target = Path(current_dir) / filename
+        create_backup(target)
+        target.write_text(content, encoding="utf-8")
+        written.append(target)
+    return written

--- a/tests/test_agent_adapters.py
+++ b/tests/test_agent_adapters.py
@@ -32,7 +32,7 @@ class AgentAdapterTests(unittest.TestCase):
 
         self.assertEqual(
             registry.ids(),
-            ("cursor", "claude", "antigravity", "vscode"),
+            ("cursor", "claude", "antigravity", "vscode", "codex"),
         )
 
     def test_adapters_declare_output_files_and_metadata(self):
@@ -52,7 +52,15 @@ class AgentAdapterTests(unittest.TestCase):
             DEFAULT_AGENT_REGISTRY.get("vscode").output_files,
             (Path("INSTRUCTIONS.md"),),
         )
+        self.assertEqual(
+            DEFAULT_AGENT_REGISTRY.get("codex").output_files,
+            (Path("AGENTS.md"),),
+        )
         self.assertIn("activation", DEFAULT_AGENT_REGISTRY.get("cursor").metadata)
+        self.assertEqual(
+            DEFAULT_AGENT_REGISTRY.get("codex").metadata["scope"],
+            "repository",
+        )
 
     def test_legacy_wrappers_render_existing_file_contents(self):
         with workspace_tempdir() as tmp:
@@ -98,7 +106,7 @@ class AgentAdapterTests(unittest.TestCase):
             generate_quietly(
                 generate_agent_contexts,
                 "project context",
-                ["context7", "vscode", "firecrawl", "cursor", "codex"],
+                ["context7", "vscode", "firecrawl", "cursor", "unknown-agent"],
                 current_dir,
             )
 
@@ -108,6 +116,45 @@ class AgentAdapterTests(unittest.TestCase):
             self.assertFalse(
                 (current_dir / ".agent" / "rules" / "constitution.md").exists()
             )
+            self.assertFalse((current_dir / "AGENTS.md").exists())
+
+    def test_codex_adapter_renders_exact_agents_md_content(self):
+        codex = DEFAULT_AGENT_REGISTRY.get("codex")
+
+        self.assertEqual(
+            codex.render("project context"),
+            {
+                Path("AGENTS.md"): (
+                    "# RAPID OS - CODEX PROJECT INSTRUCTIONS\n"
+                    "# SOURCE OF TRUTH FOR CODEX.\n\n"
+                    "project context"
+                )
+            },
+        )
+
+    def test_generate_agent_contexts_writes_codex_agents_md_when_selected(self):
+        with workspace_tempdir() as tmp:
+            current_dir = Path(tmp)
+
+            generate_quietly(
+                generate_agent_contexts,
+                "project context",
+                ["codex"],
+                current_dir,
+            )
+
+            self.assertEqual(
+                (current_dir / "AGENTS.md").read_text(encoding="utf-8"),
+                "# RAPID OS - CODEX PROJECT INSTRUCTIONS\n"
+                "# SOURCE OF TRUTH FOR CODEX.\n\n"
+                "project context",
+            )
+            self.assertFalse((current_dir / ".cursorrules").exists())
+            self.assertFalse((current_dir / "CLAUDE.md").exists())
+            self.assertFalse(
+                (current_dir / ".agent" / "rules" / "constitution.md").exists()
+            )
+            self.assertFalse((current_dir / "INSTRUCTIONS.md").exists())
 
     def test_adapter_activation_keeps_backup_behavior(self):
         with workspace_tempdir() as tmp:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,6 +42,16 @@ class CliSmokeTests(unittest.TestCase):
             ["cursor", "codex"],
         )
 
+    def test_scope_command_remains_available(self):
+        parser = create_parser()
+        subparsers = next(
+            action
+            for action in parser._actions
+            if isinstance(action, argparse._SubParsersAction)
+        )
+
+        self.assertIn("scope", subparsers.choices)
+
     def test_rapid_help_smoke(self):
         repo_root = Path(__file__).resolve().parents[1]
         env = os.environ.copy()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ import sys
 import unittest
 from pathlib import Path
 
-from rapid_os.cli.main import create_parser
+from rapid_os.cli.main import create_parser, parse_agent_selection
 
 
 class CliSmokeTests(unittest.TestCase):
@@ -30,6 +30,16 @@ class CliSmokeTests(unittest.TestCase):
                 "prompt",
                 "guide",
             },
+        )
+
+    def test_agent_selection_default_remains_cursor_only(self):
+        self.assertEqual(parse_agent_selection(""), ["cursor"])
+        self.assertEqual(parse_agent_selection("   "), ["cursor"])
+
+    def test_agent_selection_includes_codex_when_explicitly_selected(self):
+        self.assertEqual(
+            parse_agent_selection("1, 5"),
+            ["cursor", "codex"],
         )
 
     def test_rapid_help_smoke(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,11 +17,13 @@ class ProjectConfigTests(unittest.TestCase):
     def test_missing_config_returns_current_defaults(self):
         with workspace_tempdir() as tmp:
             config_file = Path(tmp) / ".rapid-os" / "config.json"
+            config = load_project_config(config_file)
 
             self.assertEqual(
-                load_project_config(config_file),
+                config,
                 {"tools": ["cursor", "claude", "antigravity", "vscode"]},
             )
+            self.assertNotIn("codex", config["tools"])
 
     def test_valid_config_loads(self):
         with workspace_tempdir() as tmp:

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -1,0 +1,216 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from rapid_os.domain.scope import (
+    NOT_SPECIFIED,
+    ScopeSpec,
+    normalize_mode,
+    parse_list,
+    render_acceptance,
+    render_scope_artifacts,
+    render_specs,
+    render_tasks,
+    write_scope_artifacts,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def workspace_tempdir():
+    return tempfile.TemporaryDirectory(dir=REPO_ROOT)
+
+
+def sample_spec():
+    return ScopeSpec(
+        initiative_name="Checkout Flow",
+        mode="new feature",
+        business_objective="Increase completed purchases",
+        problem_statement="Users abandon checkout before payment",
+        scope=["Add payment step", "Send receipt email"],
+        out_of_scope=["Subscriptions"],
+        actors_users=["Shopper", "Admin"],
+        main_flow=["Shopper opens cart", "Shopper pays"],
+        edge_cases=["Payment declined", "Email service unavailable"],
+        business_rules=["Orders require payment confirmation"],
+        technical_constraints=["Use existing payment provider"],
+        affected_files_modules=["checkout.py", "payments.py"],
+        data_impact="Adds order receipt timestamp",
+        acceptance_criteria=["Payment creates order", "Receipt email is queued"],
+        testing_strategy=["Unit test payment service", "Integration test checkout"],
+        implementation_tasks=["Create payment endpoint", "Queue receipt email"],
+    )
+
+
+class ScopeSpecTests(unittest.TestCase):
+    def test_mode_normalization_supports_expected_modes_and_aliases(self):
+        self.assertEqual(normalize_mode("1"), "new feature")
+        self.assertEqual(normalize_mode("feature"), "new feature")
+        self.assertEqual(normalize_mode("2"), "refactor")
+        self.assertEqual(normalize_mode("refactoring"), "refactor")
+        self.assertEqual(normalize_mode("3"), "bugfix")
+        self.assertEqual(normalize_mode("fix"), "bugfix")
+        self.assertEqual(normalize_mode("4"), "legacy hardening")
+        self.assertEqual(normalize_mode("legacy"), "legacy hardening")
+        self.assertEqual(normalize_mode("unknown"), "new feature")
+
+    def test_list_parsing_supports_commas_and_semicolons(self):
+        self.assertEqual(
+            parse_list("alpha, beta; gamma ,, ; delta"),
+            ["alpha", "beta", "gamma", "delta"],
+        )
+        self.assertEqual(parse_list("   "), [])
+
+    def test_render_specs_exact_content(self):
+        self.assertEqual(
+            render_specs(sample_spec()),
+            "# SPEC: Checkout Flow\n\n"
+            "## Mode\nnew feature\n\n"
+            "## Business Objective\nIncrease completed purchases\n\n"
+            "## Problem Statement\nUsers abandon checkout before payment\n\n"
+            "## Scope\n- Add payment step\n- Send receipt email\n\n"
+            "## Out of Scope\n- Subscriptions\n\n"
+            "## Actors / Users\n- Shopper\n- Admin\n\n"
+            "## Main Flow\n- Shopper opens cart\n- Shopper pays\n\n"
+            "## Edge Cases\n- Payment declined\n- Email service unavailable\n\n"
+            "## Business Rules\n- Orders require payment confirmation\n\n"
+            "## Technical Constraints\n- Use existing payment provider\n\n"
+            "## Affected Files / Modules\n- checkout.py\n- payments.py\n\n"
+            "## Data Impact\nAdds order receipt timestamp",
+        )
+
+    def test_render_tasks_exact_content(self):
+        self.assertEqual(
+            render_tasks(sample_spec()),
+            "# TASKS: Checkout Flow\n\n"
+            "## Implementation Tasks\n"
+            "- [ ] Create payment endpoint\n"
+            "- [ ] Queue receipt email\n\n"
+            "## Execution Notes\n"
+            "- Work from `SPECS.md` as the source of scope.\n"
+            "- Validate each task against `ACCEPTANCE.md`.\n"
+            "- Keep implementation changes inside the documented scope.",
+        )
+
+    def test_render_acceptance_exact_content(self):
+        self.assertEqual(
+            render_acceptance(sample_spec()),
+            "# ACCEPTANCE: Checkout Flow\n\n"
+            "## Acceptance Criteria\n"
+            "- [ ] Payment creates order\n"
+            "- [ ] Receipt email is queued\n\n"
+            "## Testing Strategy\n"
+            "- Unit test payment service\n"
+            "- Integration test checkout\n\n"
+            "## Definition of Done\n"
+            "- [ ] Acceptance criteria reviewed\n"
+            "- [ ] Testing strategy completed or explicitly deferred\n"
+            "- [ ] Implementation matches `SPECS.md`\n"
+            "- [ ] Tasks in `TASKS.md` are complete or intentionally deferred",
+        )
+
+    def test_blank_fields_render_as_not_specified(self):
+        spec = ScopeSpec(
+            initiative_name="",
+            mode="",
+            business_objective="",
+            problem_statement="",
+            scope=[],
+            out_of_scope=[],
+            actors_users=[],
+            main_flow=[],
+            edge_cases=[],
+            business_rules=[],
+            technical_constraints=[],
+            affected_files_modules=[],
+            data_impact="",
+            acceptance_criteria=[],
+            testing_strategy=[],
+            implementation_tasks=[],
+        )
+
+        self.assertIn(f"# SPEC: {NOT_SPECIFIED}", render_specs(spec))
+        self.assertIn(f"## Scope\n{NOT_SPECIFIED}", render_specs(spec))
+        self.assertIn(f"## Data Impact\n{NOT_SPECIFIED}", render_specs(spec))
+        self.assertIn(f"## Implementation Tasks\n{NOT_SPECIFIED}", render_tasks(spec))
+        self.assertIn(
+            f"## Acceptance Criteria\n{NOT_SPECIFIED}",
+            render_acceptance(spec),
+        )
+        self.assertIn(
+            f"## Testing Strategy\n{NOT_SPECIFIED}",
+            render_acceptance(spec),
+        )
+
+    def test_blank_list_items_are_ignored_before_rendering(self):
+        spec = ScopeSpec(
+            initiative_name="Whitespace Lists",
+            mode="refactor",
+            business_objective="Keep artifacts clean",
+            problem_statement="Blank list items should not render as empty bullets",
+            scope=["  ", "Keep this"],
+            out_of_scope=[""],
+            actors_users=[],
+            main_flow=[],
+            edge_cases=[],
+            business_rules=[],
+            technical_constraints=[],
+            affected_files_modules=[],
+            data_impact="",
+            acceptance_criteria=["  ", "Reviewed"],
+            testing_strategy=["  "],
+            implementation_tasks=["", "Ship cleanup"],
+        )
+
+        self.assertIn("## Scope\n- Keep this", render_specs(spec))
+        self.assertIn(f"## Out of Scope\n{NOT_SPECIFIED}", render_specs(spec))
+        self.assertIn(
+            "## Acceptance Criteria\n- [ ] Reviewed",
+            render_acceptance(spec),
+        )
+        self.assertIn(
+            f"## Testing Strategy\n{NOT_SPECIFIED}",
+            render_acceptance(spec),
+        )
+        self.assertIn(
+            "## Implementation Tasks\n- [ ] Ship cleanup",
+            render_tasks(spec),
+        )
+
+    def test_write_scope_artifacts_creates_all_files(self):
+        with workspace_tempdir() as tmp:
+            current_dir = Path(tmp)
+
+            written = write_scope_artifacts(sample_spec(), current_dir)
+
+            self.assertEqual(
+                [path.name for path in written],
+                ["SPECS.md", "TASKS.md", "ACCEPTANCE.md"],
+            )
+            self.assertTrue((current_dir / "SPECS.md").exists())
+            self.assertTrue((current_dir / "TASKS.md").exists())
+            self.assertTrue((current_dir / "ACCEPTANCE.md").exists())
+
+            for filename, content in render_scope_artifacts(sample_spec()).items():
+                self.assertEqual(
+                    (current_dir / filename).read_text(encoding="utf-8"),
+                    content,
+                )
+
+    def test_write_scope_artifacts_creates_backups_when_files_exist(self):
+        with workspace_tempdir() as tmp:
+            current_dir = Path(tmp)
+            for filename in ("SPECS.md", "TASKS.md", "ACCEPTANCE.md"):
+                (current_dir / filename).write_text("old", encoding="utf-8")
+
+            write_scope_artifacts(sample_spec(), current_dir)
+
+            for filename in ("SPECS.md", "TASKS.md", "ACCEPTANCE.md"):
+                backups = list(current_dir.glob(f"{filename}.*.bak"))
+                self.assertEqual(len(backups), 1)
+                self.assertEqual(backups[0].read_text(encoding="utf-8"), "old")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This PR implements issue #10 for Rapid OS v2.

## What changed
- upgraded `rapid scope` from a minimal wizard into a structured spec generator
- added generation of:
  - `SPECS.md`
  - `TASKS.md`
  - `ACCEPTANCE.md`
- moved scope rendering and writing logic into `rapid_os/domain/scope.py`
- added backups before overwriting generated scope artifacts
- added tests for mode normalization, list parsing, exact rendering, exact written content, blank-field handling, and backups
- updated README and architecture docs

## Compatibility
- `rapid scope` keeps the same command name
- `SPECS.md` remains the primary artifact
- `rapid prompt` remains compatible
- `TASKS.md` and `ACCEPTANCE.md` are additive
- no changes were made to adapters, Codex support, config, MCP, scanner, validation, or install scripts

## Follow-up
Next issue: #11 Implement validation and diagnostics commands for Rapid OS v2