### PR TITLE
Rapid OS v2: add validation and diagnostics commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,42 @@ Tabla completa de comandos disponibles en Rapid OS y sus resultados.
 | `rapid mcp`                  | **Configura MCP Servers**. Genera conectores para Bases de Datos y Herramientas.                | Crea `postgres_mcp.json` o similar para que la IA pueda ejecutar SQL y ver esquemas.              |
 | `rapid vision <image_path>`  | **Inyección Visual**. Procesa una imagen para extraer contexto de diseño.                       | Genera una descripción de texto/código de la imagen para que la IA "vea" el diseño.               |
 | `rapid deploy <target>`      | **Asistente de Despliegue**. Genera IaC para la nube elegida.                                   | Crea `Dockerfile`, `docker-compose.yml` o scripts de Terraform para el target (aws, vercel, gcp). |
+| `rapid validate`             | **ValidaciÃ³n de Proyecto**. Revisa templates, estÃ¡ndares, config, herramientas y contexto.      | No escribe archivos. Sale con `0` si no hay errores y `1` si encuentra errores de validaciÃ³n.     |
+| `rapid doctor`               | **DiagnÃ³stico Local**. Revisa rutas resueltas, templates, Node/npx opcional y proyecto actual.  | No escribe archivos. Usa advertencias para capacidades opcionales como Node/npx.                  |
+| `rapid inspect-context`      | **InspecciÃ³n de Contexto**. Ensambla y previsualiza el contexto final antes de generar archivos. | No escribe archivos. Muestra secciones incluidas, herramientas seleccionadas y preview final.     |
+
+---
+
+### ValidaciÃ³n y DiagnÃ³sticos
+
+Antes de regenerar contexto o usar Rapid OS en CI, puedes validar el estado del proyecto:
+
+```bash
+rapid validate
+rapid validate --json
+rapid validate --strict
+```
+
+`rapid validate` falla con cÃ³digo `1` cuando hay errores, como `tech-stack.md` o `topology.md` faltantes, JSON invÃ¡lido en templates MCP, herramientas desconocidas en `.rapid-os/config.json`, combinaciones stack/topologÃ­a incompatibles o contexto ensamblado vacÃ­o. Con `--strict`, las advertencias tambiÃ©n devuelven `1`.
+
+Para revisar la instalaciÃ³n local sin modificar nada:
+
+```bash
+rapid doctor
+rapid doctor --json
+```
+
+`rapid doctor` reporta rutas resueltas, directorio de templates activo, estado del proyecto actual y disponibilidad opcional de Node/npx.
+
+Para ver el contexto final antes de escribir archivos de agente:
+
+```bash
+rapid inspect-context
+rapid inspect-context --summary
+rapid inspect-context --json
+```
+
+`rapid inspect-context` usa el mismo ensamblado de contexto que la generaciÃ³n normal, pero no escribe `.cursorrules`, `CLAUDE.md`, `INSTRUCTIONS.md`, `AGENTS.md` ni archivos de Antigravity.
 
 ---
 

--- a/docs/architecture/rapid-os-v2.md
+++ b/docs/architecture/rapid-os-v2.md
@@ -16,6 +16,7 @@ Issue #6 started the Rapid OS v2 migration with extraction, not a rewrite. Issue
 - `rapid_os.core.output` contains shared CLI output helpers.
 - `rapid_os.domain.agents` is now a compatibility facade for the existing generation helpers.
 - `rapid_os.domain.scope` renders and writes structured spec-driven development artifacts for `rapid scope`.
+- `rapid_os.domain.validation` returns pure diagnostics for templates, project standards, config/tool references, stack/topology consistency, and composed context inspection.
 - `rapid_os.adapters.agents` owns the agent adapter contract, default registry, and implementations for Cursor, Claude, Antigravity, VS Code, and Codex.
 
 The package modules avoid command execution on import. Console UTF-8 setup happens when the CLI entrypoint runs, so importing reusable helpers remains lightweight for tests and future integrations.
@@ -50,9 +51,21 @@ The scope workflow collects initiative details, mode, business objective, proble
 
 Scope rendering is deterministic and local. Rapid OS does not infer tasks or acceptance criteria with AI in this workflow. Blank fields are rendered as `_Not specified._`, and comma- or semicolon-separated answers become Markdown lists or checklists. Existing `SPECS.md`, `TASKS.md`, and `ACCEPTANCE.md` files are backed up before being overwritten.
 
+## Validation and Diagnostics
+
+Issue #11 adds validation as an additive diagnostics layer. The validation service returns `Diagnostic` entries with `info`, `warning`, and `error` levels plus stable diagnostic codes. The domain module does not print, exit, or write files; the CLI owns rendering and process exit behavior.
+
+New commands:
+
+- `rapid validate` checks templates, project standards, config/tool ids, adapter render contracts, stack/topology consistency, and the assembled project context before generation. It supports `--json` and `--strict`.
+- `rapid doctor` reports resolved paths, template health, optional Node/npx availability, and project checks when the current directory already contains `.rapid-os/`. It supports `--json`.
+- `rapid inspect-context` composes the final context using the same context assembly path as generation, then prints included sections, selected tools, and a preview. It supports `--json` and `--summary`.
+
+Exit codes are intentionally simple: `0` means no validation errors, `1` means validation errors were found, and `--strict` makes warnings fail with `1` too. `inspect-context` does not render agent-specific previews in this migration step.
+
 ## Compatibility Guarantees
 
-- Existing commands remain available: `init`, `skill`, `mcp`, `scope`, `deploy`, `vision`, `refine`, `guide`, and the current `prompt` command.
+- Existing commands remain available: `init`, `skill`, `mcp`, `scope`, `deploy`, `vision`, `refine`, `guide`, the current `prompt` command, and the additive diagnostics commands `validate`, `doctor`, and `inspect-context`.
 - Existing aliases that call `python rapid.py` continue to work.
 - Existing import users can still read common compatibility constants from `rapid.py`, including `SCRIPT_DIR`, `TEMPLATES_DIR`, `CURRENT_DIR`, `PROJECT_RAPID_DIR`, and `CONFIG_FILE`.
 - Existing import users can still call `generate_cursor_rules`, `generate_claude_config`, `generate_antigravity_config`, and `generate_vscode_instructions`; those helpers now delegate to adapters.
@@ -63,12 +76,12 @@ Scope rendering is deterministic and local. Rapid OS does not infer tasks or acc
 
 ## Intentionally Unchanged
 
-This migration does not redesign MCP generation, add validation commands, change install scripts, generate global Codex config, or add `AGENTS.override.md`.
+This migration does not redesign MCP generation, change install scripts, generate global Codex config, add agent-specific context previews, or add `AGENTS.override.md`.
 
 Some command workflows still live in `rapid_os.cli.main` because moving them wholesale into new abstractions would be a larger behavior-changing rewrite. The priority here is to isolate reusable logic first, then migrate command domains incrementally.
 
 ## Remaining Migration Work
 
-Future Codex work can add Codex-specific skill placement, deeper Codex configuration, validation helpers, or nested instruction-file support. Future scope work can add non-interactive flags, richer templates, or validation. Those additions should remain behind the existing boundaries and be introduced in separate PRs.
+Future Codex work can add Codex-specific skill placement, deeper Codex configuration, or nested instruction-file support. Future scope work can add non-interactive flags or richer templates. Future diagnostics work can add richer machine-readable categories, more formal stack/topology metadata, and agent-specific dry-run previews. Those additions should remain behind the existing boundaries and be introduced in separate PRs.
 
 Command flows can be split further by domain once the adapter boundary is stable.

--- a/rapid_os/cli/main.py
+++ b/rapid_os/cli/main.py
@@ -2,8 +2,10 @@ import argparse
 import json
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
+from rapid_os.adapters.agents import DEFAULT_AGENT_REGISTRY
 from rapid_os.core.config import load_project_config, save_project_config
 from rapid_os.core.context import compose_project_context
 from rapid_os.core.filesystem import check_node_installed, create_backup
@@ -28,6 +30,20 @@ from rapid_os.domain.scope import (
     normalize_mode,
     parse_list,
     write_scope_artifacts,
+)
+from rapid_os.domain.validation import (
+    ERROR,
+    INFO,
+    WARNING,
+    Diagnostic,
+    ValidationReport,
+    inspect_project_context,
+    validate_composed_context,
+    validate_project,
+    validate_project_config,
+    validate_project_standards,
+    validate_stack_topology,
+    validate_templates,
 )
 
 
@@ -511,6 +527,124 @@ def generate_prompt(args):
     print("\n" + "=" * 50)
 
 
+def render_validation_report(report, json_output=False, strict=False):
+    if json_output:
+        print(json.dumps(report.to_dict(strict=strict), indent=2))
+        return report.exit_code(strict=strict)
+
+    for diagnostic in report.diagnostics:
+        line = f"[{diagnostic.level}] {diagnostic.code} {diagnostic.message}"
+        if diagnostic.path:
+            line += f" ({diagnostic.path})"
+        print(line)
+        if diagnostic.hint:
+            print(f"  hint: {diagnostic.hint}")
+
+    counts = report.counts()
+    print(
+        "Summary: "
+        f"{counts[INFO]} info, {counts[WARNING]} warning, {counts[ERROR]} error"
+    )
+    return report.exit_code(strict=strict)
+
+
+def validate_command(args):
+    report = validate_project(
+        PROJECT_RAPID_DIR,
+        CURRENT_DIR,
+        CONFIG_FILE,
+        TEMPLATES_DIR,
+        DEFAULT_AGENT_REGISTRY,
+    )
+    sys.exit(render_validation_report(report, args.json, args.strict))
+
+
+def doctor_command(args):
+    diagnostics = [
+        Diagnostic(INFO, "RAPID900", f"Current directory: {CURRENT_DIR}", CURRENT_DIR),
+        Diagnostic(INFO, "RAPID901", f"Rapid home: {RAPID_HOME}", RAPID_HOME),
+        Diagnostic(INFO, "RAPID902", f"Script directory: {SCRIPT_DIR}", SCRIPT_DIR),
+        Diagnostic(INFO, "RAPID903", f"Templates directory: {TEMPLATES_DIR}", TEMPLATES_DIR),
+        Diagnostic(
+            INFO,
+            "RAPID904",
+            f"Project Rapid OS directory: {PROJECT_RAPID_DIR}",
+            PROJECT_RAPID_DIR,
+        ),
+        Diagnostic(INFO, "RAPID905", f"Config file: {CONFIG_FILE}", CONFIG_FILE),
+    ]
+
+    if not check_node_installed():
+        diagnostics.append(
+            Diagnostic(
+                WARNING,
+                "RAPID906",
+                "Node.js/npx is not available. Remote skills and some MCP flows may not work.",
+            )
+        )
+
+    report = ValidationReport(tuple(diagnostics)).merge(validate_templates(TEMPLATES_DIR))
+
+    if PROJECT_RAPID_DIR.exists():
+        report = report.merge(
+            validate_project_standards(PROJECT_RAPID_DIR),
+            validate_project_config(CONFIG_FILE, DEFAULT_AGENT_REGISTRY),
+            validate_stack_topology(PROJECT_RAPID_DIR),
+            validate_composed_context(PROJECT_RAPID_DIR, CURRENT_DIR),
+        )
+    else:
+        report = report.extend(
+            (
+                Diagnostic(
+                    INFO,
+                    "RAPID907",
+                    "No Rapid OS project detected in the current directory.",
+                    PROJECT_RAPID_DIR,
+                ),
+            )
+        )
+
+    sys.exit(render_validation_report(report, args.json, args.strict))
+
+
+def inspect_context_command(args):
+    inspection = inspect_project_context(PROJECT_RAPID_DIR, CURRENT_DIR, CONFIG_FILE)
+
+    if args.json:
+        print(
+            json.dumps(
+                inspection.to_dict(
+                    strict=False,
+                    include_context=not args.summary,
+                ),
+                indent=2,
+            )
+        )
+        sys.exit(inspection.report.exit_code())
+
+    render_validation_report(inspection.report)
+    print("\nIncluded sections:")
+    if inspection.included_sections:
+        for section in inspection.included_sections:
+            print(f"- {section}")
+    else:
+        print("- none")
+
+    print("\nSelected tools:")
+    if inspection.selected_tools:
+        for tool in inspection.selected_tools:
+            print(f"- {tool}")
+    else:
+        print("- none")
+
+    print(f"\nContext length: {len(inspection.context)} characters")
+    if not args.summary:
+        print("\n--- Context Preview ---")
+        print(inspection.context)
+
+    sys.exit(inspection.report.exit_code())
+
+
 def show_guide():
     print("📘 RAPID OS - COMANDOS")
     print(" init    -> Configurar proyecto")
@@ -519,6 +653,9 @@ def show_guide():
     print(" vision  -> Agregar referencias visuales")
     print(" scope   -> Crear specs")
     print(" prompt  -> Generar prompt para IA")
+    print(" validate -> Validar proyecto Rapid OS")
+    print(" doctor  -> Diagnosticar instalacion local")
+    print(" inspect-context -> Previsualizar contexto ensamblado")
 
 
 def create_parser():
@@ -542,6 +679,15 @@ def create_parser():
     refine = subparsers.add_parser("refine")
     refine.add_argument("file")
     subparsers.add_parser("prompt")
+    validate = subparsers.add_parser("validate")
+    validate.add_argument("--json", action="store_true")
+    validate.add_argument("--strict", action="store_true")
+    doctor = subparsers.add_parser("doctor")
+    doctor.add_argument("--json", action="store_true")
+    doctor.add_argument("--strict", action="store_true")
+    inspect_context = subparsers.add_parser("inspect-context")
+    inspect_context.add_argument("--json", action="store_true")
+    inspect_context.add_argument("--summary", action="store_true")
     subparsers.add_parser("guide")
     return parser
 
@@ -567,6 +713,12 @@ def main(argv=None):
         refine_standard(args)
     elif args.command == "prompt":
         generate_prompt(args)
+    elif args.command == "validate":
+        validate_command(args)
+    elif args.command == "doctor":
+        doctor_command(args)
+    elif args.command == "inspect-context":
+        inspect_context_command(args)
     elif args.command == "guide":
         show_guide()
     else:

--- a/rapid_os/domain/validation.py
+++ b/rapid_os/domain/validation.py
@@ -1,0 +1,711 @@
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from rapid_os.adapters.agents import DEFAULT_AGENT_REGISTRY
+from rapid_os.core.config import DEFAULT_PROJECT_CONFIG
+from rapid_os.core.context import STANDARDS_PRIORITY, compose_project_context
+
+
+INFO = "info"
+WARNING = "warning"
+ERROR = "error"
+
+KNOWN_RESEARCH_TOOLS = ("context7", "firecrawl")
+REQUIRED_TEMPLATE_DIRS = ("stacks", "topologies", "archetypes", "mcp")
+REQUIRED_STANDARD_FILES = ("tech-stack.md", "topology.md")
+OPTIONAL_STANDARD_FILES = ("security.md", "business.md", "coding-rules.md")
+
+PLACEHOLDER_PATTERNS = (
+    re.compile(r"\{\{[^}\n]+\}\}"),
+    re.compile(r"<TODO>", re.IGNORECASE),
+    re.compile(r"\bTODO\b"),
+    re.compile(r"YOUR_API_KEY_HERE"),
+    re.compile(r"REPLACE_ME"),
+    re.compile(r"\[(PASSWORD|PROJECT-ID|PROJECT_ID)\]", re.IGNORECASE),
+)
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    level: str
+    code: str
+    message: str
+    path: Path | None = None
+    hint: str | None = None
+
+    def to_dict(self):
+        return {
+            "level": self.level,
+            "code": self.code,
+            "message": self.message,
+            "path": str(self.path) if self.path else None,
+            "hint": self.hint,
+        }
+
+
+@dataclass(frozen=True)
+class ValidationReport:
+    diagnostics: tuple[Diagnostic, ...] = ()
+
+    @property
+    def has_errors(self):
+        return any(diagnostic.level == ERROR for diagnostic in self.diagnostics)
+
+    @property
+    def has_warnings(self):
+        return any(diagnostic.level == WARNING for diagnostic in self.diagnostics)
+
+    def counts(self):
+        return {
+            INFO: sum(1 for diagnostic in self.diagnostics if diagnostic.level == INFO),
+            WARNING: sum(
+                1 for diagnostic in self.diagnostics if diagnostic.level == WARNING
+            ),
+            ERROR: sum(1 for diagnostic in self.diagnostics if diagnostic.level == ERROR),
+        }
+
+    def extend(self, diagnostics: Iterable[Diagnostic]):
+        return ValidationReport(self.diagnostics + tuple(diagnostics))
+
+    def merge(self, *reports):
+        diagnostics = list(self.diagnostics)
+        for report in reports:
+            diagnostics.extend(report.diagnostics)
+        return ValidationReport(tuple(diagnostics))
+
+    def exit_code(self, strict=False):
+        if self.has_errors or (strict and self.has_warnings):
+            return 1
+        return 0
+
+    def to_dict(self, strict=False):
+        return {
+            "ok": self.exit_code(strict=strict) == 0,
+            "summary": self.counts(),
+            "diagnostics": [
+                diagnostic.to_dict() for diagnostic in self.diagnostics
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class ContextInspection:
+    report: ValidationReport
+    context: str
+    included_sections: tuple[str, ...]
+    selected_tools: tuple[str, ...]
+
+    def to_dict(self, strict=False, include_context=True):
+        data = self.report.to_dict(strict=strict)
+        data["context"] = {
+            "included_sections": list(self.included_sections),
+            "selected_tools": list(self.selected_tools),
+            "length": len(self.context),
+            "preview": self.context if include_context else None,
+        }
+        return data
+
+
+def detect_placeholders(content: str):
+    matches = []
+    for pattern in PLACEHOLDER_PATTERNS:
+        matches.extend(match.group(0) for match in pattern.finditer(content))
+    return tuple(sorted(set(matches)))
+
+
+def validate_templates(templates_dir: Path):
+    diagnostics = [
+        Diagnostic(
+            INFO,
+            "RAPID100",
+            f"Using templates directory: {templates_dir}",
+            templates_dir,
+        )
+    ]
+
+    if not templates_dir.exists():
+        diagnostics.append(
+            Diagnostic(
+                ERROR,
+                "RAPID101",
+                "Templates directory does not exist.",
+                templates_dir,
+            )
+        )
+        return ValidationReport(tuple(diagnostics))
+
+    if not templates_dir.is_dir():
+        diagnostics.append(
+            Diagnostic(
+                ERROR,
+                "RAPID102",
+                "Templates path is not a directory.",
+                templates_dir,
+            )
+        )
+        return ValidationReport(tuple(diagnostics))
+
+    for dirname in REQUIRED_TEMPLATE_DIRS:
+        directory = templates_dir / dirname
+        if not directory.exists():
+            diagnostics.append(
+                Diagnostic(
+                    ERROR,
+                    "RAPID103",
+                    f"Required template directory missing: {dirname}",
+                    directory,
+                )
+            )
+            continue
+        if not directory.is_dir():
+            diagnostics.append(
+                Diagnostic(
+                    ERROR,
+                    "RAPID104",
+                    f"Required template path is not a directory: {dirname}",
+                    directory,
+                )
+            )
+            continue
+        if dirname in ("stacks", "topologies") and not list(directory.glob("*.md")):
+            diagnostics.append(
+                Diagnostic(
+                    ERROR,
+                    "RAPID105",
+                    f"Required template directory has no Markdown templates: {dirname}",
+                    directory,
+                )
+            )
+
+    for template_file in _iter_template_files(templates_dir):
+        diagnostics.extend(_validate_template_file(template_file))
+
+    return ValidationReport(tuple(diagnostics))
+
+
+def validate_project(
+    project_rapid_dir: Path,
+    current_dir: Path,
+    config_file: Path,
+    templates_dir: Path,
+    registry=DEFAULT_AGENT_REGISTRY,
+):
+    template_report = validate_templates(templates_dir)
+    standards_report = validate_project_standards(project_rapid_dir)
+    config_report = validate_project_config(config_file, registry)
+    compatibility_report = validate_stack_topology(project_rapid_dir)
+    context_report = validate_composed_context(project_rapid_dir, current_dir)
+    return template_report.merge(
+        standards_report,
+        config_report,
+        compatibility_report,
+        context_report,
+    )
+
+
+def validate_project_standards(project_rapid_dir: Path):
+    diagnostics = []
+    standards_dir = project_rapid_dir / "standards"
+
+    if not project_rapid_dir.exists():
+        return ValidationReport(
+            (
+                Diagnostic(
+                    ERROR,
+                    "RAPID200",
+                    "Rapid OS project directory is missing. Run 'rapid init' first.",
+                    project_rapid_dir,
+                ),
+            )
+        )
+
+    if not standards_dir.exists():
+        return ValidationReport(
+            (
+                Diagnostic(
+                    ERROR,
+                    "RAPID201",
+                    "Project standards directory is missing.",
+                    standards_dir,
+                ),
+            )
+        )
+
+    for filename in REQUIRED_STANDARD_FILES:
+        path = standards_dir / filename
+        if not path.exists():
+            diagnostics.append(
+                Diagnostic(
+                    ERROR,
+                    "RAPID202",
+                    f"Required standard missing: {filename}",
+                    path,
+                )
+            )
+            continue
+        diagnostics.extend(_validate_markdown_context_file(path, required=True))
+
+    for filename in OPTIONAL_STANDARD_FILES:
+        path = standards_dir / filename
+        if not path.exists():
+            diagnostics.append(
+                Diagnostic(
+                    WARNING,
+                    "RAPID203",
+                    f"Optional standard missing: {filename}",
+                    path,
+                )
+            )
+            continue
+        diagnostics.extend(_validate_markdown_context_file(path, required=False))
+
+    return ValidationReport(tuple(diagnostics))
+
+
+def validate_project_config(config_file: Path, registry=DEFAULT_AGENT_REGISTRY):
+    diagnostics = []
+
+    if not config_file.exists():
+        diagnostics.append(
+            Diagnostic(
+                WARNING,
+                "RAPID300",
+                "Project config missing; Rapid OS will use default tools.",
+                config_file,
+            )
+        )
+        config = DEFAULT_PROJECT_CONFIG.copy()
+    else:
+        try:
+            config = json.loads(config_file.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            return ValidationReport(
+                (
+                    Diagnostic(
+                        ERROR,
+                        "RAPID301",
+                        f"Project config is invalid JSON: {exc.msg}",
+                        config_file,
+                    ),
+                )
+            )
+        except OSError as exc:
+            return ValidationReport(
+                (
+                    Diagnostic(
+                        ERROR,
+                        "RAPID302",
+                        f"Project config could not be read: {exc}",
+                        config_file,
+                    ),
+                )
+            )
+
+    tools = config.get("tools", [])
+    if not isinstance(tools, list):
+        return ValidationReport(
+            (
+                Diagnostic(
+                    ERROR,
+                    "RAPID303",
+                    "Project config field 'tools' must be a list.",
+                    config_file,
+                ),
+            )
+        )
+
+    if not tools:
+        diagnostics.append(
+            Diagnostic(
+                WARNING,
+                "RAPID304",
+                "No tools are selected in project config.",
+                config_file,
+            )
+        )
+
+    adapter_ids = set(registry.ids())
+    known_tools = adapter_ids | set(KNOWN_RESEARCH_TOOLS)
+
+    for tool in tools:
+        if not isinstance(tool, str):
+            diagnostics.append(
+                Diagnostic(
+                    ERROR,
+                    "RAPID305",
+                    "Tool ids in project config must be strings.",
+                    config_file,
+                )
+            )
+            continue
+        if tool in KNOWN_RESEARCH_TOOLS:
+            diagnostics.append(
+                Diagnostic(
+                    INFO,
+                    "RAPID306",
+                    f"Known research tool selected: {tool}",
+                    config_file,
+                )
+            )
+            continue
+        if tool not in known_tools:
+            diagnostics.append(
+                Diagnostic(
+                    ERROR,
+                    "RAPID307",
+                    f"Unknown tool reference: {tool}",
+                    config_file,
+                    hint=(
+                        "Use registered agents or known research tools: "
+                        + ", ".join(sorted(known_tools))
+                    ),
+                )
+            )
+            continue
+        diagnostics.extend(_validate_adapter_render_contract(tool, registry, config_file))
+
+    return ValidationReport(tuple(diagnostics))
+
+
+def validate_stack_topology(project_rapid_dir: Path):
+    standards_dir = project_rapid_dir / "standards"
+    stack_file = standards_dir / "tech-stack.md"
+    topology_file = standards_dir / "topology.md"
+
+    if not stack_file.exists() or not topology_file.exists():
+        return ValidationReport(())
+
+    try:
+        stack_content = stack_file.read_text(encoding="utf-8")
+        topology_content = topology_file.read_text(encoding="utf-8")
+    except OSError:
+        return ValidationReport(())
+
+    stack = infer_stack(stack_content)
+    topology = infer_topology(topology_content)
+    diagnostics = []
+
+    if stack:
+        diagnostics.append(
+            Diagnostic(INFO, "RAPID400", f"Detected stack: {stack}", stack_file)
+        )
+    if topology:
+        diagnostics.append(
+            Diagnostic(
+                INFO,
+                "RAPID401",
+                f"Detected topology: {topology}",
+                topology_file,
+            )
+        )
+
+    if stack == "docs-modern" and topology and topology != "doc-site":
+        diagnostics.append(
+            Diagnostic(
+                ERROR,
+                "RAPID402",
+                "docs-modern stack should use doc-site topology.",
+                topology_file,
+            )
+        )
+    if topology == "doc-site" and stack and stack != "docs-modern":
+        diagnostics.append(
+            Diagnostic(
+                ERROR,
+                "RAPID403",
+                "doc-site topology should use docs-modern stack.",
+                stack_file,
+            )
+        )
+    if topology == "front-end-only" and stack in ("python-ai", "nodejs-ai"):
+        diagnostics.append(
+            Diagnostic(
+                ERROR,
+                "RAPID404",
+                f"{stack} stack requires backend/database capabilities and conflicts with front-end-only topology.",
+                stack_file,
+            )
+        )
+    if topology == "fullstack-baas" and stack == "python-ai":
+        diagnostics.append(
+            Diagnostic(
+                WARNING,
+                "RAPID405",
+                "fullstack-baas is tuned for integrated web apps; verify this Python AI pairing is intentional.",
+                stack_file,
+            )
+        )
+
+    return ValidationReport(tuple(diagnostics))
+
+
+def validate_composed_context(project_rapid_dir: Path, current_dir: Path):
+    diagnostics = []
+    context = compose_project_context(project_rapid_dir, current_dir)
+
+    if not context.strip():
+        diagnostics.append(
+            Diagnostic(
+                ERROR,
+                "RAPID500",
+                "Assembled project context is empty.",
+                project_rapid_dir / "standards",
+            )
+        )
+        return ValidationReport(tuple(diagnostics))
+
+    diagnostics.append(
+        Diagnostic(
+            INFO,
+            "RAPID501",
+            f"Assembled project context length: {len(context)} characters.",
+            project_rapid_dir,
+        )
+    )
+
+    placeholders = detect_placeholders(context)
+    if placeholders:
+        diagnostics.append(
+            Diagnostic(
+                WARNING,
+                "RAPID502",
+                "Assembled project context contains unresolved placeholders: "
+                + ", ".join(placeholders),
+                project_rapid_dir,
+            )
+        )
+
+    return ValidationReport(tuple(diagnostics))
+
+
+def inspect_project_context(
+    project_rapid_dir: Path,
+    current_dir: Path,
+    config_file: Path,
+):
+    context = compose_project_context(project_rapid_dir, current_dir)
+    diagnostics = list(validate_project_standards(project_rapid_dir).diagnostics)
+    diagnostics.extend(validate_composed_context(project_rapid_dir, current_dir).diagnostics)
+    selected_tools = _read_selected_tools(config_file)
+
+    return ContextInspection(
+        report=ValidationReport(tuple(diagnostics)),
+        context=context,
+        included_sections=_included_context_sections(project_rapid_dir, current_dir),
+        selected_tools=tuple(selected_tools),
+    )
+
+
+def infer_stack(content: str):
+    normalized = content.lower()
+    if "modern docs" in normalized or "docusaurus" in normalized:
+        return "docs-modern"
+    if "python ai agent" in normalized or "fastapi" in normalized:
+        return "python-ai"
+    if "nodejs ai agent" in normalized or "bun.js" in normalized:
+        return "nodejs-ai"
+    if "creative & motion" in normalized:
+        return "frontend-creative"
+    if "modern web" in normalized or "next.js" in normalized:
+        return "web-modern"
+    return None
+
+
+def infer_topology(content: str):
+    normalized = content.lower()
+    if "documentation site" in normalized or "docusaurus.config" in normalized:
+        return "doc-site"
+    if "frontend only" in normalized or "backend:** none" in normalized:
+        return "front-end-only"
+    if "serverless" in normalized or "baas" in normalized:
+        return "fullstack-baas"
+    if "separated frontend" in normalized or "decoupled" in normalized:
+        return "fullstack-separated"
+    return None
+
+
+def _iter_template_files(templates_dir: Path):
+    for directory_name in REQUIRED_TEMPLATE_DIRS:
+        directory = templates_dir / directory_name
+        if directory.exists() and directory.is_dir():
+            yield from sorted(path for path in directory.rglob("*") if path.is_file())
+
+
+def _validate_template_file(path: Path):
+    diagnostics = []
+    try:
+        content = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return (
+            Diagnostic(
+                ERROR,
+                "RAPID106",
+                "Template file is not valid UTF-8.",
+                path,
+            ),
+        )
+    except OSError as exc:
+        return (
+            Diagnostic(
+                ERROR,
+                "RAPID107",
+                f"Template file could not be read: {exc}",
+                path,
+            ),
+        )
+
+    if not content.strip():
+        diagnostics.append(
+            Diagnostic(WARNING, "RAPID108", "Template file is empty.", path)
+        )
+
+    if path.suffix.lower() == ".json":
+        try:
+            json.loads(content)
+        except json.JSONDecodeError as exc:
+            diagnostics.append(
+                Diagnostic(
+                    ERROR,
+                    "RAPID109",
+                    f"Template JSON is invalid: {exc.msg}",
+                    path,
+                )
+            )
+
+    placeholders = detect_placeholders(content)
+    if placeholders:
+        diagnostics.append(
+            Diagnostic(
+                WARNING,
+                "RAPID110",
+                "Template contains unresolved placeholders: "
+                + ", ".join(placeholders),
+                path,
+            )
+        )
+
+    return tuple(diagnostics)
+
+
+def _validate_markdown_context_file(path: Path, required: bool):
+    diagnostics = []
+    try:
+        content = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return (
+            Diagnostic(
+                ERROR,
+                "RAPID204",
+                "Standard file is not valid UTF-8.",
+                path,
+            ),
+        )
+    except OSError as exc:
+        return (
+            Diagnostic(
+                ERROR,
+                "RAPID205",
+                f"Standard file could not be read: {exc}",
+                path,
+            ),
+        )
+
+    if required and not content.strip():
+        diagnostics.append(
+            Diagnostic(ERROR, "RAPID206", "Required standard file is empty.", path)
+        )
+    elif not content.strip():
+        diagnostics.append(
+            Diagnostic(WARNING, "RAPID207", "Optional standard file is empty.", path)
+        )
+
+    placeholders = detect_placeholders(content)
+    if placeholders:
+        diagnostics.append(
+            Diagnostic(
+                WARNING,
+                "RAPID208",
+                "Standard file contains unresolved placeholders: "
+                + ", ".join(placeholders),
+                path,
+            )
+        )
+
+    return tuple(diagnostics)
+
+
+def _validate_adapter_render_contract(tool: str, registry, path: Path):
+    diagnostics = []
+    try:
+        adapter = registry.get(tool)
+    except KeyError:
+        return (
+            Diagnostic(
+                ERROR,
+                "RAPID308",
+                f"Selected agent has no registered adapter: {tool}",
+                path,
+            ),
+        )
+
+    try:
+        rendered = adapter.render("Rapid OS validation context")
+    except Exception as exc:
+        return (
+            Diagnostic(
+                ERROR,
+                "RAPID309",
+                f"Adapter '{tool}' failed to render validation context: {exc}",
+                path,
+            ),
+        )
+
+    for output in adapter.outputs:
+        relative_path = output.relative_path
+        if relative_path not in rendered:
+            diagnostics.append(
+                Diagnostic(
+                    ERROR,
+                    "RAPID310",
+                    f"Adapter '{tool}' did not render declared output: {relative_path.as_posix()}",
+                    path,
+                )
+            )
+        if relative_path.is_absolute() or ".." in relative_path.parts:
+            diagnostics.append(
+                Diagnostic(
+                    ERROR,
+                    "RAPID311",
+                    f"Adapter '{tool}' declares unsafe output path: {relative_path.as_posix()}",
+                    path,
+                )
+            )
+
+    return tuple(diagnostics)
+
+
+def _read_selected_tools(config_file: Path):
+    if not config_file.exists():
+        return DEFAULT_PROJECT_CONFIG["tools"]
+    try:
+        config = json.loads(config_file.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return ()
+    tools = config.get("tools", [])
+    if not isinstance(tools, list):
+        return ()
+    return tuple(tool for tool in tools if isinstance(tool, str))
+
+
+def _included_context_sections(project_rapid_dir: Path, current_dir: Path):
+    sections = []
+    standards_dir = project_rapid_dir / "standards"
+    for filename in STANDARDS_PRIORITY:
+        if (standards_dir / filename).exists():
+            sections.append(filename)
+    if (current_dir / "references" / "VISION_CONTEXT.md").exists():
+        sections.append("references/VISION_CONTEXT.md")
+    return tuple(sections)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import os
 import subprocess
 import sys
@@ -28,6 +29,9 @@ class CliSmokeTests(unittest.TestCase):
                 "mcp",
                 "refine",
                 "prompt",
+                "validate",
+                "doctor",
+                "inspect-context",
                 "guide",
             },
         )
@@ -83,6 +87,66 @@ class CliSmokeTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn(b"init", result.stdout)
+
+    def test_validation_command_help_smoke(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        env = os.environ.copy()
+        env["PYTHONDONTWRITEBYTECODE"] = "1"
+
+        for command in ("validate", "doctor", "inspect-context"):
+            result = subprocess.run(
+                [sys.executable, "rapid.py", command, "--help"],
+                cwd=repo_root,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn(command.encode(), result.stdout)
+
+    def test_validate_json_exits_nonzero_for_current_uninitialized_project(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        env = os.environ.copy()
+        env["PYTHONDONTWRITEBYTECODE"] = "1"
+
+        result = subprocess.run(
+            [sys.executable, "rapid.py", "validate", "--json"],
+            cwd=repo_root,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        self.assertEqual(result.returncode, 1)
+        payload = json.loads(result.stdout.decode("utf-8"))
+        self.assertFalse(payload["ok"])
+        self.assertIn("diagnostics", payload)
+
+    def test_doctor_json_exit_codes_cover_success_and_strict_warning(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        env = os.environ.copy()
+        env["PYTHONDONTWRITEBYTECODE"] = "1"
+
+        relaxed = subprocess.run(
+            [sys.executable, "rapid.py", "doctor", "--json"],
+            cwd=repo_root,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        strict = subprocess.run(
+            [sys.executable, "rapid.py", "doctor", "--json", "--strict"],
+            cwd=repo_root,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        self.assertEqual(relaxed.returncode, 0, relaxed.stderr)
+        self.assertEqual(strict.returncode, 1, strict.stderr)
+        self.assertTrue(json.loads(relaxed.stdout.decode("utf-8"))["ok"])
+        self.assertFalse(json.loads(strict.stdout.decode("utf-8"))["ok"])
 
 
 if __name__ == "__main__":

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,198 @@
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from rapid_os.adapters.agents import AgentRegistry
+from rapid_os.adapters.agents.base import AgentAdapter, AgentOutput
+from rapid_os.cli.main import render_validation_report
+from rapid_os.domain.validation import (
+    Diagnostic,
+    ERROR,
+    INFO,
+    WARNING,
+    ValidationReport,
+    detect_placeholders,
+    inspect_project_context,
+    validate_composed_context,
+    validate_project_config,
+    validate_stack_topology,
+    validate_templates,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def workspace_tempdir():
+    return tempfile.TemporaryDirectory(dir=REPO_ROOT)
+
+
+def create_minimal_templates(root: Path):
+    templates_dir = root / "templates"
+    for dirname in ("stacks", "topologies", "archetypes", "mcp"):
+        (templates_dir / dirname).mkdir(parents=True)
+    (templates_dir / "stacks" / "web-modern.md").write_text("stack", encoding="utf-8")
+    (templates_dir / "topologies" / "front-end-only.md").write_text(
+        "topology", encoding="utf-8"
+    )
+    (templates_dir / "mcp" / "postgres.json").write_text("{}", encoding="utf-8")
+    return templates_dir
+
+
+class BrokenAdapter(AgentAdapter):
+    id = "broken"
+    name = "Broken"
+    outputs = (AgentOutput(Path("BROKEN.md"), "broken"),)
+
+    def render(self, context):
+        return {}
+
+
+class ValidationTests(unittest.TestCase):
+    def test_missing_required_template_directory_is_error(self):
+        with workspace_tempdir() as tmp:
+            root = Path(tmp)
+            templates_dir = create_minimal_templates(root)
+            (templates_dir / "mcp" / "postgres.json").unlink()
+            (templates_dir / "mcp").rmdir()
+
+            report = validate_templates(templates_dir)
+
+            self.assertTrue(report.has_errors)
+            self.assertIn("RAPID103", [diagnostic.code for diagnostic in report.diagnostics])
+
+    def test_invalid_mcp_json_template_is_error(self):
+        with workspace_tempdir() as tmp:
+            root = Path(tmp)
+            templates_dir = create_minimal_templates(root)
+            (templates_dir / "mcp" / "postgres.json").write_text(
+                "{invalid", encoding="utf-8"
+            )
+
+            report = validate_templates(templates_dir)
+
+            self.assertTrue(report.has_errors)
+            self.assertIn("RAPID109", [diagnostic.code for diagnostic in report.diagnostics])
+
+    def test_placeholder_detection_finds_common_unresolved_tokens(self):
+        placeholders = detect_placeholders(
+            "Use {{APP_NAME}}, YOUR_API_KEY_HERE, [PASSWORD], and TODO."
+        )
+
+        self.assertIn("{{APP_NAME}}", placeholders)
+        self.assertIn("YOUR_API_KEY_HERE", placeholders)
+        self.assertIn("[PASSWORD]", placeholders)
+        self.assertIn("TODO", placeholders)
+
+    def test_unknown_tool_id_is_error(self):
+        with workspace_tempdir() as tmp:
+            config_file = Path(tmp) / ".rapid-os" / "config.json"
+            config_file.parent.mkdir()
+            config_file.write_text('{"tools": ["cursor", "unknown-agent"]}', encoding="utf-8")
+
+            report = validate_project_config(config_file)
+
+            self.assertTrue(report.has_errors)
+            self.assertIn("RAPID307", [diagnostic.code for diagnostic in report.diagnostics])
+
+    def test_research_tools_are_known_non_agent_tools(self):
+        with workspace_tempdir() as tmp:
+            config_file = Path(tmp) / ".rapid-os" / "config.json"
+            config_file.parent.mkdir()
+            config_file.write_text('{"tools": ["context7", "firecrawl"]}', encoding="utf-8")
+
+            report = validate_project_config(config_file)
+
+            self.assertFalse(report.has_errors)
+            self.assertEqual(
+                [diagnostic.code for diagnostic in report.diagnostics],
+                ["RAPID306", "RAPID306"],
+            )
+
+    def test_missing_adapter_render_contract_is_error_with_test_registry(self):
+        with workspace_tempdir() as tmp:
+            config_file = Path(tmp) / ".rapid-os" / "config.json"
+            config_file.parent.mkdir()
+            config_file.write_text('{"tools": ["broken"]}', encoding="utf-8")
+            registry = AgentRegistry([BrokenAdapter()])
+
+            report = validate_project_config(config_file, registry)
+
+            self.assertTrue(report.has_errors)
+            self.assertIn("RAPID310", [diagnostic.code for diagnostic in report.diagnostics])
+
+    def test_empty_context_is_error(self):
+        with workspace_tempdir() as tmp:
+            current_dir = Path(tmp)
+            project_dir = current_dir / ".rapid-os"
+            (project_dir / "standards").mkdir(parents=True)
+
+            report = validate_composed_context(project_dir, current_dir)
+
+            self.assertTrue(report.has_errors)
+            self.assertIn("RAPID500", [diagnostic.code for diagnostic in report.diagnostics])
+
+    def test_stack_topology_mismatch_is_error(self):
+        with workspace_tempdir() as tmp:
+            current_dir = Path(tmp)
+            standards_dir = current_dir / ".rapid-os" / "standards"
+            standards_dir.mkdir(parents=True)
+            (standards_dir / "tech-stack.md").write_text(
+                "# TECH STACK: MODERN DOCS\nDocusaurus 3+", encoding="utf-8"
+            )
+            (standards_dir / "topology.md").write_text(
+                "# TOPOLOGY: FRONTEND ONLY\nBackend: NONE", encoding="utf-8"
+            )
+
+            report = validate_stack_topology(current_dir / ".rapid-os")
+
+            self.assertTrue(report.has_errors)
+            self.assertIn("RAPID402", [diagnostic.code for diagnostic in report.diagnostics])
+
+    def test_inspect_context_reports_sections_tools_and_preview(self):
+        with workspace_tempdir() as tmp:
+            current_dir = Path(tmp)
+            project_dir = current_dir / ".rapid-os"
+            standards_dir = project_dir / "standards"
+            standards_dir.mkdir(parents=True)
+            (standards_dir / "tech-stack.md").write_text("stack", encoding="utf-8")
+            (standards_dir / "topology.md").write_text("topology", encoding="utf-8")
+            config_file = project_dir / "config.json"
+            config_file.write_text('{"tools": ["cursor"]}', encoding="utf-8")
+
+            inspection = inspect_project_context(project_dir, current_dir, config_file)
+
+            self.assertIn("tech-stack.md", inspection.included_sections)
+            self.assertIn("topology.md", inspection.included_sections)
+            self.assertEqual(inspection.selected_tools, ("cursor",))
+            self.assertIn("stack", inspection.context)
+
+    def test_report_exit_codes_support_errors_and_strict_warnings(self):
+        success = ValidationReport((Diagnostic(INFO, "I", "ok"),))
+        warning = ValidationReport((Diagnostic(WARNING, "W", "warn"),))
+        error = ValidationReport((Diagnostic(ERROR, "E", "bad"),))
+
+        self.assertEqual(success.exit_code(), 0)
+        self.assertEqual(warning.exit_code(), 0)
+        self.assertEqual(warning.exit_code(strict=True), 1)
+        self.assertEqual(error.exit_code(), 1)
+
+    def test_json_output_shape(self):
+        report = ValidationReport((Diagnostic(INFO, "RAPID000", "ok"),))
+        output = io.StringIO()
+
+        with redirect_stdout(output):
+            exit_code = render_validation_report(report, json_output=True)
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["summary"], {"info": 1, "warning": 0, "error": 0})
+        self.assertEqual(payload["diagnostics"][0]["code"], "RAPID000")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This PR implements issue #11 for Rapid OS v2.

## What changed
- added a pure validation/diagnostics service
- added new commands:
  - `rapid validate`
  - `rapid doctor`
  - `rapid inspect-context`
- added validation for:
  - templates
  - standards
  - config/tool ids
  - adapter render contracts
  - stack/topology compatibility
  - composed context
- added support for human-readable and JSON output
- added CI-friendly exit code behavior
- added tests and docs

## Compatibility
- existing generation behavior remains unchanged
- project config shape remains unchanged
- adapters, MCP, scope, install scripts, and Codex behavior were not changed
- unknown tools remain tolerated by generation for compatibility, but now surface as validation errors

## Exit codes
- `0`: no errors
- `1`: validation errors
- `--strict`: warnings also fail

## Follow-up
Next issue: #12 Implement a project scanner for safer initialization in Rapid OS v2