### PR TITLE
Rapid OS v2: add project scanner for safer init

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,12 +204,25 @@ Reinicia tu terminal después de la instalación para cargar el comando `rapid`.
     rapid init
     ```
 3.  Sigue el asistente interactivo:
+    - **Scanner seguro**: Rapid OS revisa seÃ±ales locales como `package.json`, `tsconfig.json`, Docker, tests, monorepo, base de datos y provider de deploy para sugerir stack/topologÃ­a. Nada se aplica sin confirmaciÃ³n.
     - **Tech Stack**: Define las tecnologías permitidas (ej. "Solo React Functional Components").
     - **Arquetipo**: "Corporate" para código estricto con tests, o "MVP" para velocidad.
     - **Reglas de Negocio**: Importa tus documentos existentes o extráelos de tu cabeza.
     - **Capacidades de Investigación (Nuevo)**: Activa `Context7` (Docs) y `Firecrawl` (Web Scraping) para que tu IA pueda investigar librerías y sitios web por sí misma.
 
 > **Para Refactorización**: Al ejecutar esto en un proyecto legacy, Rapid OS inyectará un archivo `.cursorrules` o `.agent` que obligará a la IA a respetar los nuevos estándares en cualquier refactorización futura, evitando que imite el código antiguo ("code drift").
+
+Para conservar el flujo manual anterior, usa:
+
+```bash
+rapid init --no-scan
+```
+
+Si pasas `--stack`, ese valor manda sobre cualquier sugerencia del scanner:
+
+```bash
+rapid init --stack web-modern
+```
 
 ### 2. Refinamiento de Reglas (Rapid Refine)
 
@@ -327,7 +340,7 @@ Tabla completa de comandos disponibles en Rapid OS y sus resultados.
 
 | Comando                      | Descripción                                                                                     | Resultado / Output                                                                                |
 | :--------------------------- | :---------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------ |
-| `rapid init`                 | **Inicializa Rapid OS** en el directorio actual. Detecta stack y crea archivos de contexto.     | Crea `.cursorrules`, `.agent/rules`, `.rapid-os/` y backups de config existente.                  |
+| `rapid init`                 | **Inicializa Rapid OS**. Escanea seÃ±ales locales y sugiere stack/topologÃ­a con confirmaciÃ³n.   | Crea `.cursorrules`, `.agent/rules`, `.rapid-os/` y backups de config existente. Usa `--no-scan` para modo manual. |
 | `rapid scope`                | **Asistente de Alcance**. Te entrevista para definir una feature, refactor, bugfix o hardening. | Genera `SPECS.md`, `TASKS.md` y `ACCEPTANCE.md` con backups antes de sobrescribir.                |
 | `rapid refine <file>`        | **Refinamiento de Reglas**. Mejora cualquier documento de reglas usando IA.                     | Genera un Mega-Prompt para que pegues en tu chat y la IA reescriba el archivo profesionalmente.   |
 | `rapid skill add <name>`     | **Instala una Skill** desde el registro comunitario.                                            | Descarga la skill en `.cursor/skills/<name>` y la activa en el contexto.                          |

--- a/docs/architecture/rapid-os-v2.md
+++ b/docs/architecture/rapid-os-v2.md
@@ -17,6 +17,7 @@ Issue #6 started the Rapid OS v2 migration with extraction, not a rewrite. Issue
 - `rapid_os.domain.agents` is now a compatibility facade for the existing generation helpers.
 - `rapid_os.domain.scope` renders and writes structured spec-driven development artifacts for `rapid scope`.
 - `rapid_os.domain.validation` returns pure diagnostics for templates, project standards, config/tool references, stack/topology consistency, and composed context inspection.
+- `rapid_os.domain.scanner` detects project characteristics and returns reviewable init suggestions without printing, prompting, writing files, or mutating project choices.
 - `rapid_os.adapters.agents` owns the agent adapter contract, default registry, and implementations for Cursor, Claude, Antigravity, VS Code, and Codex.
 
 The package modules avoid command execution on import. Console UTF-8 setup happens when the CLI entrypoint runs, so importing reusable helpers remains lightweight for tests and future integrations.
@@ -63,6 +64,14 @@ New commands:
 
 Exit codes are intentionally simple: `0` means no validation errors, `1` means validation errors were found, and `--strict` makes warnings fail with `1` too. `inspect-context` does not render agent-specific previews in this migration step.
 
+## Project Scanner
+
+Issue #12 adds a bounded project scanner for safer initialization. The scanner detects probable language, framework, package manager, Docker presence, testing framework, monorepo signals, database hints, and deployment provider hints from local project files. It does not perform network calls, install dependencies, write files, or update `.rapid-os/config.json`.
+
+`rapid init` runs the scanner by default before stack/topology selection. The CLI prints a compact summary and suggested init choices, then asks for confirmation. Suggestions are applied only after the user accepts them. If the user rejects suggestions, if evidence is mixed, or if no confident suggestion exists, `rapid init` falls back to the existing manual menus.
+
+The scanner only suggests stack and topology in this migration step. `rapid init --no-scan` preserves the manual initialization flow, and `rapid init --stack <name>` remains authoritative over scanner stack suggestions.
+
 ## Compatibility Guarantees
 
 - Existing commands remain available: `init`, `skill`, `mcp`, `scope`, `deploy`, `vision`, `refine`, `guide`, the current `prompt` command, and the additive diagnostics commands `validate`, `doctor`, and `inspect-context`.
@@ -71,17 +80,18 @@ Exit codes are intentionally simple: `0` means no validation errors, `1` means v
 - Existing import users can still call `generate_cursor_rules`, `generate_claude_config`, `generate_antigravity_config`, and `generate_vscode_instructions`; those helpers now delegate to adapters.
 - Generated files remain in their current locations: `.cursorrules`, `CLAUDE.md`, `.agent/rules/constitution.md`, `INSTRUCTIONS.md`, `AGENTS.md`, `claude_desktop_config.json`, `SPECS.md`, `TASKS.md`, `ACCEPTANCE.md`, `DEPLOY.md`, and `references/VISION_CONTEXT.md`.
 - Project config remains `.rapid-os/config.json`.
+- Scanner results are not stored in project config.
 - Missing project config still defaults to Cursor, Claude, Antigravity, and VS Code only; Codex must be explicitly selected or added to `tools`.
 - Template discovery still prefers a source checkout `templates/` directory and falls back to `~/.rapid-os/templates`.
 
 ## Intentionally Unchanged
 
-This migration does not redesign MCP generation, change install scripts, generate global Codex config, add agent-specific context previews, or add `AGENTS.override.md`.
+This migration does not redesign MCP generation, validation commands, install scripts, generate global Codex config, add agent-specific context previews, or add `AGENTS.override.md`.
 
 Some command workflows still live in `rapid_os.cli.main` because moving them wholesale into new abstractions would be a larger behavior-changing rewrite. The priority here is to isolate reusable logic first, then migrate command domains incrementally.
 
 ## Remaining Migration Work
 
-Future Codex work can add Codex-specific skill placement, deeper Codex configuration, or nested instruction-file support. Future scope work can add non-interactive flags or richer templates. Future diagnostics work can add richer machine-readable categories, more formal stack/topology metadata, and agent-specific dry-run previews. Those additions should remain behind the existing boundaries and be introduced in separate PRs.
+Future Codex work can add Codex-specific skill placement, deeper Codex configuration, or nested instruction-file support. Future scope work can add non-interactive flags or richer templates. Future diagnostics work can add richer machine-readable categories, more formal stack/topology metadata, and agent-specific dry-run previews. Future scanner work can add a standalone scan command, persisted scan metadata, deeper monorepo targeting, or richer framework mappings. Those additions should remain behind the existing boundaries and be introduced in separate PRs.
 
 Command flows can be split further by domain once the adapter boundary is stable.

--- a/rapid_os/cli/main.py
+++ b/rapid_os/cli/main.py
@@ -25,6 +25,7 @@ from rapid_os.core.paths import (
     TEMPLATES_DIR,
 )
 from rapid_os.domain.agents import generate_agent_contexts
+from rapid_os.domain.scanner import scan_project, suggest_init_choices
 from rapid_os.domain.scope import (
     ScopeSpec,
     normalize_mode,
@@ -74,13 +75,70 @@ def regenerate_context():
     generate_agent_contexts(full_context, tools, CURRENT_DIR)
 
 
+def print_scan_summary(scan, suggestions, stack_override=None):
+    print("\nRapid OS detected:")
+    for category, label in (
+        ("language", "Language"),
+        ("framework", "Framework"),
+        ("package_manager", "Package manager"),
+        ("testing", "Testing"),
+        ("docker", "Docker"),
+        ("monorepo", "Monorepo"),
+        ("database", "Database"),
+        ("deploy_provider", "Deploy provider"),
+    ):
+        values = scan.values(category)
+        if values:
+            print(f"- {label}: {', '.join(values)}")
+        else:
+            print(f"- {label}: none detected")
+
+    if suggestions.has_any() or stack_override:
+        print("\nSuggested init choices:")
+        if stack_override:
+            print(f"- Stack: {stack_override} (--stack)")
+        elif suggestions.stack:
+            print(f"- Stack: {suggestions.stack.value}")
+        if suggestions.topology:
+            print(f"- Topology: {suggestions.topology.value}")
+
+
+def confirm_scan_suggestions(scan, suggestions, stack_override=None):
+    if not suggestions.has_any():
+        return False
+
+    print_scan_summary(scan, suggestions, stack_override)
+    try:
+        response = input("\nUse these suggestions? [Y/n]: ").strip().lower()
+    except EOFError:
+        response = "n"
+    return response != "n"
+
+
 def init_project(args):
     print_step("Inicializando Rapid OS...")
+    scan = None
+    suggestions = None
+    use_suggestions = False
+
+    if not getattr(args, "no_scan", False):
+        scan = scan_project(CURRENT_DIR)
+        suggestions = suggest_init_choices(scan)
+        if suggestions.has_any():
+            use_suggestions = confirm_scan_suggestions(scan, suggestions, args.stack)
+        else:
+            print_scan_summary(scan, suggestions, args.stack)
+
     standards_dest = PROJECT_RAPID_DIR / "standards"
     standards_dest.mkdir(parents=True, exist_ok=True)
 
     # 1. Stack
-    if not args.stack:
+    suggested_stack = suggestions.stack.value if suggestions and suggestions.stack else None
+    if args.stack:
+        stack_name = args.stack
+    elif use_suggestions and suggested_stack:
+        stack_name = suggested_stack
+    else:
         stacks_path = TEMPLATES_DIR / "stacks"
         if not stacks_path.exists():
             print_error(f"Templates no encontrados en {stacks_path}")
@@ -95,15 +153,19 @@ def init_project(args):
             stack_name = stacks[idx] if 0 <= idx < len(stacks) else stacks[0]
         except Exception:
             stack_name = stacks[0]
-    else:
-        stack_name = args.stack
 
     # 2. Topología
     topologies_path = TEMPLATES_DIR / "topologies"
     if not topologies_path.exists():
         topologies_path.mkdir(parents=True, exist_ok=True)
     topos = sorted([f.stem for f in topologies_path.glob("*.md")])
-    if topos:
+    topo_name = None
+    suggested_topology = (
+        suggestions.topology.value if suggestions and suggestions.topology else None
+    )
+    if use_suggestions and suggested_topology in topos:
+        topo_name = suggested_topology
+    if topos and topo_name is None:
         print("\n🏗️  SELECCIONA TOPOLOGÍA:")
         for i, t in enumerate(topos, 1):
             print(f" {i}) {t}")
@@ -112,6 +174,7 @@ def init_project(args):
             topo_name = topos[idx] if 0 <= idx < len(topos) else topos[0]
         except Exception:
             topo_name = topos[0]
+    if topo_name:
         shutil.copy(topologies_path / f"{topo_name}.md", standards_dest / "topology.md")
 
     # 3. Arquetipo
@@ -665,6 +728,7 @@ def create_parser():
     init = subparsers.add_parser("init")
     init.add_argument("--stack")
     init.add_argument("--archetype")
+    init.add_argument("--no-scan", action="store_true")
 
     skill = subparsers.add_parser("skill")
     skill.add_argument("action", choices=["list", "install", "add"])

--- a/rapid_os/domain/scanner.py
+++ b/rapid_os/domain/scanner.py
@@ -1,0 +1,676 @@
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+CONFIDENCE_HIGH = "high"
+CONFIDENCE_MEDIUM = "medium"
+CONFIDENCE_LOW = "low"
+
+IGNORED_DIRS = {
+    ".git",
+    "node_modules",
+    ".venv",
+    "venv",
+    "dist",
+    "build",
+    ".next",
+    ".docusaurus",
+    "coverage",
+    ".rapid-os",
+}
+
+DETECTION_CATEGORIES = (
+    "language",
+    "framework",
+    "package_manager",
+    "docker",
+    "testing",
+    "monorepo",
+    "database",
+    "deploy_provider",
+)
+
+
+@dataclass(frozen=True)
+class Evidence:
+    path: Path
+    reason: str
+
+    def to_dict(self):
+        return {"path": str(self.path), "reason": self.reason}
+
+
+@dataclass(frozen=True)
+class Detection:
+    category: str
+    value: str
+    confidence: str
+    evidence: tuple[Evidence, ...] = ()
+
+    def to_dict(self):
+        return {
+            "category": self.category,
+            "value": self.value,
+            "confidence": self.confidence,
+            "evidence": [item.to_dict() for item in self.evidence],
+        }
+
+
+@dataclass(frozen=True)
+class ProjectScan:
+    root: Path
+    detections: tuple[Detection, ...] = ()
+
+    def by_category(self, category: str):
+        return tuple(
+            detection
+            for detection in self.detections
+            if detection.category == category
+        )
+
+    def values(self, category: str):
+        return tuple(detection.value for detection in self.by_category(category))
+
+    def has(self, category: str, value: str):
+        return value in self.values(category)
+
+    def to_dict(self):
+        return {
+            "root": str(self.root),
+            "detections": [detection.to_dict() for detection in self.detections],
+        }
+
+
+@dataclass(frozen=True)
+class InitSuggestion:
+    field: str
+    value: str
+    confidence: str
+    reason: str
+    evidence: tuple[Evidence, ...] = ()
+
+    def to_dict(self):
+        return {
+            "field": self.field,
+            "value": self.value,
+            "confidence": self.confidence,
+            "reason": self.reason,
+            "evidence": [item.to_dict() for item in self.evidence],
+        }
+
+
+@dataclass(frozen=True)
+class InitSuggestions:
+    stack: InitSuggestion | None = None
+    topology: InitSuggestion | None = None
+
+    def has_any(self):
+        return self.stack is not None or self.topology is not None
+
+    def to_dict(self):
+        return {
+            "stack": self.stack.to_dict() if self.stack else None,
+            "topology": self.topology.to_dict() if self.topology else None,
+        }
+
+
+def scan_project(project_dir: Path):
+    root = Path(project_dir)
+    files = _collect_files(root)
+    package_manifests = _load_package_manifests(files, root)
+    text_cache = {}
+
+    detections = []
+    detections.extend(_detect_languages(files, root, package_manifests))
+    detections.extend(_detect_frameworks(files, root, package_manifests, text_cache))
+    detections.extend(_detect_package_managers(files, root))
+    detections.extend(_detect_docker(files, root))
+    detections.extend(_detect_testing(files, root, package_manifests))
+    detections.extend(_detect_monorepo(files, root, package_manifests))
+    detections.extend(_detect_databases(files, root, package_manifests, text_cache))
+    detections.extend(_detect_deploy_providers(files, root))
+
+    return ProjectScan(root=root, detections=_dedupe_detections(detections))
+
+
+def suggest_init_choices(scan: ProjectScan):
+    framework_values = set(scan.values("framework"))
+    language_values = set(scan.values("language"))
+    database_values = set(scan.values("database"))
+
+    app_frameworks = framework_values & {
+        "docusaurus",
+        "nextjs",
+        "fastapi",
+    }
+    has_conflict = len(app_frameworks) > 1
+
+    stack = None
+    topology = None
+
+    if not has_conflict and scan.has("framework", "docusaurus"):
+        evidence = _first_evidence(scan, "framework", "docusaurus")
+        stack = InitSuggestion(
+            "stack",
+            "docs-modern",
+            CONFIDENCE_HIGH,
+            "Docusaurus project detected.",
+            evidence,
+        )
+        topology = InitSuggestion(
+            "topology",
+            "doc-site",
+            CONFIDENCE_HIGH,
+            "Docusaurus projects match the doc-site topology.",
+            evidence,
+        )
+    elif not has_conflict and scan.has("framework", "nextjs"):
+        evidence = _first_evidence(scan, "framework", "nextjs")
+        stack = InitSuggestion(
+            "stack",
+            "web-modern",
+            CONFIDENCE_HIGH,
+            "Next.js project detected.",
+            evidence,
+        )
+        if "supabase" in database_values:
+            topology = InitSuggestion(
+                "topology",
+                "fullstack-baas",
+                CONFIDENCE_MEDIUM,
+                "Next.js and Supabase hints were detected.",
+                evidence + _first_evidence(scan, "database", "supabase"),
+            )
+    elif not has_conflict and scan.has("framework", "fastapi"):
+        evidence = _first_evidence(scan, "framework", "fastapi")
+        if "python" in language_values:
+            stack = InitSuggestion(
+                "stack",
+                "python-ai",
+                CONFIDENCE_HIGH,
+                "Python and FastAPI project detected.",
+                evidence,
+            )
+            topology = InitSuggestion(
+                "topology",
+                "fullstack-separated",
+                CONFIDENCE_MEDIUM,
+                "FastAPI usually acts as a separate backend service.",
+                evidence,
+            )
+    elif not has_conflict and _has_node_ai_hints(scan):
+        evidence = (
+            _first_evidence(scan, "framework", "langchain")
+            or _first_evidence(scan, "framework", "langgraph")
+            or _first_evidence(scan, "framework", "crewai")
+        )
+        stack = InitSuggestion(
+            "stack",
+            "nodejs-ai",
+            CONFIDENCE_MEDIUM,
+            "Node.js AI framework hints were detected.",
+            evidence,
+        )
+    elif not has_conflict and _has_frontend_without_backend(scan):
+        evidence = (
+            _first_evidence(scan, "framework", "react")
+            or _first_evidence(scan, "framework", "vite")
+        )
+        topology = InitSuggestion(
+            "topology",
+            "front-end-only",
+            CONFIDENCE_MEDIUM,
+            "Frontend framework detected without backend or database hints.",
+            evidence,
+        )
+
+    return InitSuggestions(stack=stack, topology=topology)
+
+
+def _collect_files(root: Path):
+    files = []
+    if not root.exists():
+        return tuple(files)
+
+    for current_root, dirnames, filenames in os.walk(root):
+        current_path = Path(current_root)
+        dirnames[:] = [
+            dirname
+            for dirname in dirnames
+            if dirname not in IGNORED_DIRS
+            and not _is_ignored_path(current_path / dirname, root)
+        ]
+        for filename in filenames:
+            path = current_path / filename
+            if not _is_ignored_path(path, root):
+                files.append(path)
+
+    return tuple(sorted(files))
+
+
+def _is_ignored_path(path: Path, root: Path):
+    try:
+        relative = path.relative_to(root)
+    except ValueError:
+        relative = path
+    return any(part in IGNORED_DIRS for part in relative.parts)
+
+
+def _load_package_manifests(files, root: Path):
+    manifests = {}
+    for path in files:
+        if path.name != "package.json":
+            continue
+        try:
+            manifests[path] = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+            manifests[path] = {}
+    return manifests
+
+
+def _detect_languages(files, root, package_manifests):
+    detections = []
+    names = {path.name: path for path in files}
+    suffixes = {path.suffix.lower() for path in files}
+
+    for filename in ("pyproject.toml", "requirements.txt", "Pipfile", "poetry.lock"):
+        if filename in names:
+            detections.append(
+                _detection("language", "python", CONFIDENCE_HIGH, names[filename], filename)
+            )
+            break
+
+    if "package.json" in names:
+        detections.append(
+            _detection("language", "javascript", CONFIDENCE_MEDIUM, names["package.json"], "package.json")
+        )
+
+    if "tsconfig.json" in names or ".ts" in suffixes or ".tsx" in suffixes:
+        evidence_path = names.get("tsconfig.json") or _first_file_with_suffix(files, (".ts", ".tsx"))
+        detections.append(
+            _detection("language", "typescript", CONFIDENCE_HIGH, evidence_path, "TypeScript project files")
+        )
+
+    if "go.mod" in names:
+        detections.append(_detection("language", "go", CONFIDENCE_HIGH, names["go.mod"], "go.mod"))
+
+    if "Cargo.toml" in names:
+        detections.append(
+            _detection("language", "rust", CONFIDENCE_HIGH, names["Cargo.toml"], "Cargo.toml")
+        )
+
+    if not any(d.value == "python" for d in detections) and ".py" in suffixes:
+        detections.append(
+            _detection("language", "python", CONFIDENCE_LOW, _first_file_with_suffix(files, (".py",)), "Python source file")
+        )
+
+    for path, manifest in package_manifests.items():
+        dependencies = _manifest_dependencies(manifest)
+        if "typescript" in dependencies and not any(d.value == "typescript" for d in detections):
+            detections.append(
+                _detection("language", "typescript", CONFIDENCE_MEDIUM, path, "typescript dependency")
+            )
+
+    return detections
+
+
+def _detect_frameworks(files, root, package_manifests, text_cache):
+    detections = []
+    for path in files:
+        name = path.name
+        if _matches_config(name, "next.config"):
+            detections.append(_detection("framework", "nextjs", CONFIDENCE_HIGH, path, name))
+        if _matches_config(name, "docusaurus.config"):
+            detections.append(
+                _detection("framework", "docusaurus", CONFIDENCE_HIGH, path, name)
+            )
+        if _matches_config(name, "vite.config"):
+            detections.append(_detection("framework", "vite", CONFIDENCE_HIGH, path, name))
+
+    for path, manifest in package_manifests.items():
+        dependencies = _manifest_dependencies(manifest)
+        dependency_map = {
+            "next": "nextjs",
+            "react": "react",
+            "@docusaurus/core": "docusaurus",
+            "vite": "vite",
+            "langchain": "langchain",
+            "@langchain/core": "langchain",
+            "@langchain/langgraph": "langgraph",
+            "langgraph": "langgraph",
+            "crewai": "crewai",
+        }
+        for dependency, framework in dependency_map.items():
+            if dependency in dependencies:
+                detections.append(
+                    _detection(
+                        "framework",
+                        framework,
+                        CONFIDENCE_MEDIUM,
+                        path,
+                        f"{dependency} dependency",
+                    )
+                )
+
+    for path in files:
+        if path.suffix.lower() == ".py":
+            content = _read_text(path, text_cache)
+            if "FastAPI(" in content or "from fastapi" in content or "import fastapi" in content:
+                detections.append(
+                    _detection("framework", "fastapi", CONFIDENCE_LOW, path, "FastAPI reference")
+                )
+
+    for path in _python_manifest_files(files):
+        content = _read_text(path, text_cache).lower()
+        for framework in ("fastapi", "langchain", "langgraph", "crewai"):
+            if framework in content:
+                detections.append(
+                    _detection(
+                        "framework",
+                        framework,
+                        CONFIDENCE_MEDIUM,
+                        path,
+                        f"{framework} manifest reference",
+                    )
+                )
+
+    return detections
+
+
+def _detect_package_managers(files, root):
+    mapping = {
+        "package-lock.json": "npm",
+        "pnpm-lock.yaml": "pnpm",
+        "yarn.lock": "yarn",
+        "poetry.lock": "poetry",
+        "Pipfile.lock": "pipenv",
+    }
+    detections = []
+    for path in files:
+        if path.name in mapping:
+            detections.append(
+                _detection(
+                    "package_manager",
+                    mapping[path.name],
+                    CONFIDENCE_HIGH,
+                    path,
+                    path.name,
+                )
+            )
+        elif path.name.startswith("bun.lock"):
+            detections.append(
+                _detection("package_manager", "bun", CONFIDENCE_HIGH, path, path.name)
+            )
+    return detections
+
+
+def _detect_docker(files, root):
+    docker_files = {"Dockerfile", "docker-compose.yml", "docker-compose.yaml", ".dockerignore"}
+    return tuple(
+        _detection("docker", "present", CONFIDENCE_HIGH, path, path.name)
+        for path in files
+        if path.name in docker_files
+    )
+
+
+def _detect_testing(files, root, package_manifests):
+    detections = []
+    test_config_prefixes = {
+        "jest.config": "jest",
+        "vitest.config": "vitest",
+        "playwright.config": "playwright",
+        "cypress.config": "cypress",
+    }
+    for path in files:
+        for prefix, value in test_config_prefixes.items():
+            if _matches_config(path.name, prefix):
+                detections.append(
+                    _detection("testing", value, CONFIDENCE_HIGH, path, path.name)
+                )
+        if path.name == "pytest.ini":
+            detections.append(
+                _detection("testing", "pytest", CONFIDENCE_HIGH, path, "pytest.ini")
+            )
+        if _relative_parts(path, root)[0:1] == ("tests",):
+            detections.append(
+                _detection("testing", "tests-directory", CONFIDENCE_MEDIUM, path.parent, "tests directory")
+            )
+
+    for path, manifest in package_manifests.items():
+        dependencies = _manifest_dependencies(manifest)
+        for package, value in (
+            ("jest", "jest"),
+            ("vitest", "vitest"),
+            ("@playwright/test", "playwright"),
+            ("cypress", "cypress"),
+        ):
+            if package in dependencies:
+                detections.append(
+                    _detection("testing", value, CONFIDENCE_MEDIUM, path, f"{package} dependency")
+                )
+
+    for path in _python_manifest_files(files):
+        if "pytest" in _read_text(path, {}).lower():
+            detections.append(
+                _detection("testing", "pytest", CONFIDENCE_MEDIUM, path, "pytest reference")
+            )
+
+    return detections
+
+
+def _detect_monorepo(files, root, package_manifests):
+    detections = []
+    names = {path.name: path for path in files}
+    for filename, value in (
+        ("pnpm-workspace.yaml", "pnpm-workspace"),
+        ("turbo.json", "turbo"),
+        ("nx.json", "nx"),
+    ):
+        if filename in names:
+            detections.append(
+                _detection("monorepo", value, CONFIDENCE_HIGH, names[filename], filename)
+            )
+
+    for path, manifest in package_manifests.items():
+        if "workspaces" in manifest:
+            detections.append(
+                _detection("monorepo", "package-workspaces", CONFIDENCE_HIGH, path, "package.json workspaces")
+            )
+
+    root_dirs = {path.name for path in root.iterdir() if path.is_dir()} if root.exists() else set()
+    if "apps" in root_dirs and "packages" in root_dirs:
+        detections.append(
+            Detection(
+                "monorepo",
+                "apps-packages-layout",
+                CONFIDENCE_MEDIUM,
+                (
+                    Evidence(root / "apps", "apps directory"),
+                    Evidence(root / "packages", "packages directory"),
+                ),
+            )
+        )
+
+    return detections
+
+
+def _detect_databases(files, root, package_manifests, text_cache):
+    detections = []
+    for path in files:
+        relative = _relative_parts(path, root)
+        if relative and relative[0] == "supabase":
+            detections.append(
+                _detection("database", "supabase", CONFIDENCE_HIGH, path, "supabase directory")
+            )
+        if relative == ("prisma", "schema.prisma"):
+            detections.append(
+                _detection("database", "prisma", CONFIDENCE_HIGH, path, "prisma schema")
+            )
+        if path.name.startswith(".env"):
+            content = _read_text(path, text_cache).upper()
+            if "SUPABASE" in content:
+                detections.append(
+                    _detection("database", "supabase", CONFIDENCE_LOW, path, "SUPABASE env key")
+                )
+            if "DATABASE_URL" in content or "POSTGRES_URL" in content:
+                detections.append(
+                    _detection("database", "postgres", CONFIDENCE_LOW, path, "database env key")
+                )
+            if "MONGO" in content:
+                detections.append(
+                    _detection("database", "mongo", CONFIDENCE_LOW, path, "mongo env key")
+                )
+
+    dependency_map = {
+        "@supabase/supabase-js": "supabase",
+        "pg": "postgres",
+        "postgres": "postgres",
+        "prisma": "prisma",
+        "@prisma/client": "prisma",
+        "mongoose": "mongo",
+        "mongodb": "mongo",
+    }
+    for path, manifest in package_manifests.items():
+        dependencies = _manifest_dependencies(manifest)
+        for dependency, value in dependency_map.items():
+            if dependency in dependencies:
+                detections.append(
+                    _detection("database", value, CONFIDENCE_MEDIUM, path, f"{dependency} dependency")
+                )
+
+    for path in _python_manifest_files(files):
+        content = _read_text(path, text_cache).lower()
+        for package, value in (
+            ("asyncpg", "postgres"),
+            ("psycopg", "postgres"),
+            ("pymongo", "mongo"),
+            ("supabase", "supabase"),
+        ):
+            if package in content:
+                detections.append(
+                    _detection("database", value, CONFIDENCE_MEDIUM, path, f"{package} reference")
+                )
+
+    return detections
+
+
+def _detect_deploy_providers(files, root):
+    detections = []
+    for path in files:
+        relative = _relative_parts(path, root)
+        if path.name == "vercel.json" or (relative and relative[0] == ".vercel"):
+            detections.append(_detection("deploy_provider", "vercel", CONFIDENCE_HIGH, path, path.name))
+        if path.name == "netlify.toml":
+            detections.append(_detection("deploy_provider", "netlify", CONFIDENCE_HIGH, path, path.name))
+        if path.name == "wrangler.toml":
+            detections.append(_detection("deploy_provider", "cloudflare", CONFIDENCE_HIGH, path, path.name))
+        if path.name == "railway.json":
+            detections.append(_detection("deploy_provider", "railway", CONFIDENCE_HIGH, path, path.name))
+        if path.name == "fly.toml":
+            detections.append(_detection("deploy_provider", "fly", CONFIDENCE_HIGH, path, path.name))
+        if len(relative) >= 3 and relative[0:2] == (".github", "workflows"):
+            detections.append(
+                _detection("deploy_provider", "github-actions", CONFIDENCE_HIGH, path, ".github/workflows")
+            )
+    return detections
+
+
+def _detection(category, value, confidence, path, reason):
+    return Detection(category, value, confidence, (Evidence(path, reason),))
+
+
+def _dedupe_detections(detections):
+    grouped = {}
+    order = []
+    confidence_rank = {CONFIDENCE_LOW: 0, CONFIDENCE_MEDIUM: 1, CONFIDENCE_HIGH: 2}
+    for detection in detections:
+        key = (detection.category, detection.value)
+        if key not in grouped:
+            grouped[key] = detection
+            order.append(key)
+            continue
+
+        existing = grouped[key]
+        confidence = (
+            detection.confidence
+            if confidence_rank[detection.confidence] > confidence_rank[existing.confidence]
+            else existing.confidence
+        )
+        grouped[key] = Detection(
+            existing.category,
+            existing.value,
+            confidence,
+            existing.evidence + detection.evidence,
+        )
+
+    return tuple(grouped[key] for key in order)
+
+
+def _manifest_dependencies(manifest):
+    dependencies = {}
+    for key in ("dependencies", "devDependencies", "peerDependencies", "optionalDependencies"):
+        value = manifest.get(key, {})
+        if isinstance(value, dict):
+            dependencies.update(value)
+    return dependencies
+
+
+def _matches_config(filename, prefix):
+    return filename == prefix or filename.startswith(prefix + ".")
+
+
+def _read_text(path, cache):
+    if path in cache:
+        return cache[path]
+    try:
+        content = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        content = ""
+    cache[path] = content
+    return content
+
+
+def _first_file_with_suffix(files, suffixes):
+    for path in files:
+        if path.suffix.lower() in suffixes:
+            return path
+    return Path()
+
+
+def _python_manifest_files(files):
+    names = {"pyproject.toml", "requirements.txt", "Pipfile"}
+    return tuple(path for path in files if path.name in names)
+
+
+def _relative_parts(path, root):
+    try:
+        return path.relative_to(root).parts
+    except ValueError:
+        return path.parts
+
+
+def _first_evidence(scan, category, value):
+    for detection in scan.detections:
+        if detection.category == category and detection.value == value:
+            return detection.evidence
+    return ()
+
+
+def _has_node_ai_hints(scan):
+    ai_frameworks = {"langchain", "langgraph", "crewai"}
+    return (
+        "javascript" in scan.values("language")
+        or "typescript" in scan.values("language")
+    ) and bool(ai_frameworks & set(scan.values("framework")))
+
+
+def _has_frontend_without_backend(scan):
+    frontend_frameworks = {"react", "vite"}
+    backend_frameworks = {"nextjs", "fastapi"}
+    return (
+        bool(frontend_frameworks & set(scan.values("framework")))
+        and not bool(backend_frameworks & set(scan.values("framework")))
+        and not scan.values("database")
+    )

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,0 +1,265 @@
+import argparse
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+from rapid_os.cli import main as cli_main
+from rapid_os.domain.scanner import scan_project, suggest_init_choices
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def workspace_tempdir():
+    return tempfile.TemporaryDirectory(dir=REPO_ROOT)
+
+
+def write_json(path: Path, data):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def create_init_templates(root: Path):
+    templates = root / "templates"
+    for dirname in ("stacks", "topologies", "archetypes", "business"):
+        (templates / dirname).mkdir(parents=True)
+
+    for stack in ("web-modern", "docs-modern", "python-ai", "nodejs-ai"):
+        (templates / "stacks" / f"{stack}.md").write_text(
+            f"# {stack}\n", encoding="utf-8"
+        )
+
+    for topology in ("front-end-only", "doc-site", "fullstack-separated", "fullstack-baas"):
+        (templates / "topologies" / f"{topology}.md").write_text(
+            f"# {topology}\n", encoding="utf-8"
+        )
+
+    (templates / "archetypes" / "mvp").mkdir()
+    (templates / "archetypes" / "mvp" / "coding-rules.md").write_text(
+        "rules", encoding="utf-8"
+    )
+    return templates
+
+
+class ScannerTests(unittest.TestCase):
+    def test_detects_docusaurus_project_and_suggests_docs(self):
+        with workspace_tempdir() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / "docusaurus.config.ts").write_text("config", encoding="utf-8")
+            (project / "tsconfig.json").write_text("{}", encoding="utf-8")
+            (project / "package-lock.json").write_text("{}", encoding="utf-8")
+            write_json(
+                project / "package.json",
+                {"dependencies": {"@docusaurus/core": "^3.0.0"}},
+            )
+
+            scan = scan_project(project)
+            suggestions = suggest_init_choices(scan)
+
+            self.assertIn("typescript", scan.values("language"))
+            self.assertIn("docusaurus", scan.values("framework"))
+            self.assertIn("npm", scan.values("package_manager"))
+            self.assertEqual(suggestions.stack.value, "docs-modern")
+            self.assertEqual(suggestions.topology.value, "doc-site")
+
+    def test_detects_next_supabase_and_suggests_baas_topology(self):
+        with workspace_tempdir() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / "next.config.js").write_text("module.exports = {}", encoding="utf-8")
+            (project / "supabase" / "config.toml").parent.mkdir()
+            (project / "supabase" / "config.toml").write_text("", encoding="utf-8")
+            write_json(
+                project / "package.json",
+                {
+                    "dependencies": {
+                        "next": "^14.0.0",
+                        "@supabase/supabase-js": "^2.0.0",
+                    }
+                },
+            )
+
+            scan = scan_project(project)
+            suggestions = suggest_init_choices(scan)
+
+            self.assertIn("nextjs", scan.values("framework"))
+            self.assertIn("supabase", scan.values("database"))
+            self.assertEqual(suggestions.stack.value, "web-modern")
+            self.assertEqual(suggestions.topology.value, "fullstack-baas")
+
+    def test_detects_python_fastapi_and_suggests_separated_backend(self):
+        with workspace_tempdir() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / "pyproject.toml").write_text(
+                'dependencies = ["fastapi"]', encoding="utf-8"
+            )
+
+            scan = scan_project(project)
+            suggestions = suggest_init_choices(scan)
+
+            self.assertIn("python", scan.values("language"))
+            self.assertIn("fastapi", scan.values("framework"))
+            self.assertEqual(suggestions.stack.value, "python-ai")
+            self.assertEqual(suggestions.topology.value, "fullstack-separated")
+
+    def test_detects_node_ai_hints(self):
+        with workspace_tempdir() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            write_json(
+                project / "package.json",
+                {"dependencies": {"langchain": "^0.1.0"}},
+            )
+
+            scan = scan_project(project)
+            suggestions = suggest_init_choices(scan)
+
+            self.assertIn("langchain", scan.values("framework"))
+            self.assertEqual(suggestions.stack.value, "nodejs-ai")
+
+    def test_detects_frontend_without_backend_as_frontend_only(self):
+        with workspace_tempdir() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / "vite.config.ts").write_text("export default {}", encoding="utf-8")
+            write_json(
+                project / "package.json",
+                {"dependencies": {"react": "^18.0.0", "vite": "^5.0.0"}},
+            )
+
+            scan = scan_project(project)
+            suggestions = suggest_init_choices(scan)
+
+            self.assertIn("vite", scan.values("framework"))
+            self.assertEqual(suggestions.topology.value, "front-end-only")
+
+    def test_detects_testing_docker_monorepo_and_deploy_hints(self):
+        with workspace_tempdir() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / "Dockerfile").write_text("FROM python", encoding="utf-8")
+            (project / "pytest.ini").write_text("[pytest]", encoding="utf-8")
+            (project / "pnpm-workspace.yaml").write_text("packages: []", encoding="utf-8")
+            (project / "vercel.json").write_text("{}", encoding="utf-8")
+
+            scan = scan_project(project)
+
+            self.assertIn("present", scan.values("docker"))
+            self.assertIn("pytest", scan.values("testing"))
+            self.assertIn("pnpm-workspace", scan.values("monorepo"))
+            self.assertIn("vercel", scan.values("deploy_provider"))
+
+    def test_mixed_framework_evidence_avoids_strong_suggestions(self):
+        with workspace_tempdir() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            (project / "docusaurus.config.ts").write_text("config", encoding="utf-8")
+            (project / "next.config.js").write_text("config", encoding="utf-8")
+
+            suggestions = suggest_init_choices(scan_project(project))
+
+            self.assertIsNone(suggestions.stack)
+            self.assertIsNone(suggestions.topology)
+
+    def test_scanner_ignores_generated_and_dependency_directories(self):
+        with workspace_tempdir() as tmp:
+            project = Path(tmp) / "project"
+            ignored = project / "node_modules" / "next"
+            ignored.mkdir(parents=True)
+            (ignored / "package.json").write_text("{}", encoding="utf-8")
+
+            scan = scan_project(project)
+
+            self.assertNotIn("nextjs", scan.values("framework"))
+
+    def test_scanner_does_not_mutate_project_config(self):
+        with workspace_tempdir() as tmp:
+            project = Path(tmp) / "project"
+            project.mkdir()
+            write_json(project / "package.json", {"dependencies": {"next": "^14.0.0"}})
+
+            scan_project(project)
+
+            self.assertFalse((project / ".rapid-os" / "config.json").exists())
+
+
+class ScannerInitIntegrationTests(unittest.TestCase):
+    def test_parser_supports_no_scan_for_init(self):
+        parser = cli_main.create_parser()
+        args = parser.parse_args(["init", "--no-scan"])
+
+        self.assertTrue(args.no_scan)
+
+    def test_stack_override_remains_authoritative_when_accepting_suggestions(self):
+        with workspace_tempdir() as tmp:
+            root = Path(tmp)
+            project = root / "project"
+            project.mkdir()
+            templates = create_init_templates(root)
+            (project / "docusaurus.config.ts").write_text("config", encoding="utf-8")
+
+            inputs = iter(["y", "", "", "", "n", ""])
+            args = argparse.Namespace(stack="web-modern", archetype=None, no_scan=False)
+
+            with patch.object(cli_main, "CURRENT_DIR", project), patch.object(
+                cli_main, "PROJECT_RAPID_DIR", project / ".rapid-os"
+            ), patch.object(cli_main, "CONFIG_FILE", project / ".rapid-os" / "config.json"), patch.object(
+                cli_main, "TEMPLATES_DIR", templates
+            ), patch(
+                "builtins.input", lambda prompt="": next(inputs)
+            ), redirect_stdout(
+                io.StringIO()
+            ):
+                cli_main.init_project(args)
+
+            stack_content = (
+                project / ".rapid-os" / "standards" / "tech-stack.md"
+            ).read_text(encoding="utf-8")
+            topology_content = (
+                project / ".rapid-os" / "standards" / "topology.md"
+            ).read_text(encoding="utf-8")
+
+            self.assertIn("web-modern", stack_content)
+            self.assertIn("doc-site", topology_content)
+
+    def test_no_scan_preserves_manual_stack_and_topology_flow(self):
+        with workspace_tempdir() as tmp:
+            root = Path(tmp)
+            project = root / "project"
+            project.mkdir()
+            templates = create_init_templates(root)
+            (project / "docusaurus.config.ts").write_text("config", encoding="utf-8")
+
+            inputs = iter(["1", "1", "", "", "", "n", ""])
+            args = argparse.Namespace(stack=None, archetype=None, no_scan=True)
+
+            with patch.object(cli_main, "CURRENT_DIR", project), patch.object(
+                cli_main, "PROJECT_RAPID_DIR", project / ".rapid-os"
+            ), patch.object(cli_main, "CONFIG_FILE", project / ".rapid-os" / "config.json"), patch.object(
+                cli_main, "TEMPLATES_DIR", templates
+            ), patch(
+                "builtins.input", lambda prompt="": next(inputs)
+            ), redirect_stdout(
+                io.StringIO()
+            ):
+                cli_main.init_project(args)
+
+            stack_content = (
+                project / ".rapid-os" / "standards" / "tech-stack.md"
+            ).read_text(encoding="utf-8")
+            topology_content = (
+                project / ".rapid-os" / "standards" / "topology.md"
+            ).read_text(encoding="utf-8")
+
+            self.assertIn("docs-modern", stack_content)
+            self.assertIn("doc-site", topology_content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This PR implements issue #12 for Rapid OS v2.

## What changed
- added a pure project scanner domain module
- integrated scanner suggestions into `rapid init`
- added `--no-scan` to preserve the manual init path
- added detection for:
  - language
  - framework
  - package manager
  - docker
  - testing
  - monorepo
  - database
  - deploy provider
- added bounded suggestion mapping for stack/topology
- added tests and docs

## Compatibility
- existing generated files remain unchanged
- adapters, validation, MCP, Codex, scope generation, install scripts, templates, and config shape remain unchanged
- scanner suggestions require explicit user confirmation
- `rapid init --no-scan` preserves previous behavior
- `rapid init --stack <name>` remains authoritative
- scan results are not persisted in `.rapid-os/config.json`

## Follow-up
Future improvements may include standalone scan commands, deeper monorepo targeting, richer metadata, and broader framework mappings