### PR TITLE
Rapid OS v2: add MCP abstraction layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,8 @@ rapid mcp
 
 (Soporta Postgres y Supabase automáticamente).
 
+Rapid OS modela los servidores MCP internamente y renderiza la configuraciÃ³n compatible con Claude Desktop en `claude_desktop_config.json`. El flujo actual conserva soporte para filesystem, Postgres, Supabase, Context7 y Firecrawl, y avisa si hay placeholders o API keys pendientes sin bloquear la generaciÃ³n.
+
 ### 6. Referencias Visuales (Vision)
 
 Para que la IA "vea" tus diseños y no alucine el frontend:
@@ -345,7 +347,7 @@ Tabla completa de comandos disponibles en Rapid OS y sus resultados.
 | `rapid refine <file>`        | **Refinamiento de Reglas**. Mejora cualquier documento de reglas usando IA.                     | Genera un Mega-Prompt para que pegues en tu chat y la IA reescriba el archivo profesionalmente.   |
 | `rapid skill add <name>`     | **Instala una Skill** desde el registro comunitario.                                            | Descarga la skill en `.cursor/skills/<name>` y la activa en el contexto.                          |
 | `rapid skill install <path>` | **Instala una Skill Local** desde una carpeta o template privado.                               | Copia la skill local a la carpeta de skills activas del proyecto.                                 |
-| `rapid mcp`                  | **Configura MCP Servers**. Genera conectores para Bases de Datos y Herramientas.                | Crea `postgres_mcp.json` o similar para que la IA pueda ejecutar SQL y ver esquemas.              |
+| `rapid mcp`                  | **Configura MCP Servers**. Modela filesystem, BD y research tools.                              | Crea `claude_desktop_config.json` con `mcpServers` compatible y warnings para placeholders.       |
 | `rapid vision <image_path>`  | **Inyección Visual**. Procesa una imagen para extraer contexto de diseño.                       | Genera una descripción de texto/código de la imagen para que la IA "vea" el diseño.               |
 | `rapid deploy <target>`      | **Asistente de Despliegue**. Genera IaC para la nube elegida.                                   | Crea `Dockerfile`, `docker-compose.yml` o scripts de Terraform para el target (aws, vercel, gcp). |
 | `rapid validate`             | **ValidaciÃ³n de Proyecto**. Revisa templates, estÃ¡ndares, config, herramientas y contexto.      | No escribe archivos. Sale con `0` si no hay errores y `1` si encuentra errores de validaciÃ³n.     |

--- a/docs/architecture/rapid-os-v2.md
+++ b/docs/architecture/rapid-os-v2.md
@@ -18,6 +18,8 @@ Issue #6 started the Rapid OS v2 migration with extraction, not a rewrite. Issue
 - `rapid_os.domain.scope` renders and writes structured spec-driven development artifacts for `rapid scope`.
 - `rapid_os.domain.validation` returns pure diagnostics for templates, project standards, config/tool references, stack/topology consistency, and composed context inspection.
 - `rapid_os.domain.scanner` detects project characteristics and returns reviewable init suggestions without printing, prompting, writing files, or mutating project choices.
+- `rapid_os.domain.mcp` models MCP servers, generation plans, and non-blocking warnings independently from output formats.
+- `rapid_os.adapters.mcp` renders MCP models into concrete output formats, currently the existing Claude Desktop JSON shape.
 - `rapid_os.adapters.agents` owns the agent adapter contract, default registry, and implementations for Cursor, Claude, Antigravity, VS Code, and Codex.
 
 The package modules avoid command execution on import. Console UTF-8 setup happens when the CLI entrypoint runs, so importing reusable helpers remains lightweight for tests and future integrations.
@@ -72,6 +74,14 @@ Issue #12 adds a bounded project scanner for safer initialization. The scanner d
 
 The scanner only suggests stack and topology in this migration step. `rapid init --no-scan` preserves the manual initialization flow, and `rapid init --stack <name>` remains authoritative over scanner stack suggestions.
 
+## MCP Abstraction
+
+The MCP workflow now uses a reusable model and renderer boundary. `rapid_os.domain.mcp` builds a structured `McpConfig` from topology content, selected tools, current project paths, and existing MCP templates. It supports the current server ids: `filesystem`, `postgres`, `supabase`, `context7`, and `firecrawl`.
+
+Rendering is handled outside the domain model. The current renderer in `rapid_os.adapters.mcp` produces the same `{"mcpServers": ...}` JSON shape written to `claude_desktop_config.json`. The CLI remains the facade responsible for reading project files, printing warnings, creating backups, and writing the rendered output.
+
+Unresolved placeholders and missing key hints are warnings, not hard failures. This preserves the current editable starter-config behavior while making the generation plan reusable for future MCP destinations.
+
 ## Compatibility Guarantees
 
 - Existing commands remain available: `init`, `skill`, `mcp`, `scope`, `deploy`, `vision`, `refine`, `guide`, the current `prompt` command, and the additive diagnostics commands `validate`, `doctor`, and `inspect-context`.
@@ -82,11 +92,12 @@ The scanner only suggests stack and topology in this migration step. `rapid init
 - Project config remains `.rapid-os/config.json`.
 - Scanner results are not stored in project config.
 - Missing project config still defaults to Cursor, Claude, Antigravity, and VS Code only; Codex must be explicitly selected or added to `tools`.
+- `rapid mcp` still writes `claude_desktop_config.json` with the existing `mcpServers` shape.
 - Template discovery still prefers a source checkout `templates/` directory and falls back to `~/.rapid-os/templates`.
 
 ## Intentionally Unchanged
 
-This migration does not redesign MCP generation, validation commands, install scripts, generate global Codex config, add agent-specific context previews, or add `AGENTS.override.md`.
+This migration does not redesign MCP UX, validation commands, install scripts, generate global Codex config, add agent-specific context previews, or add `AGENTS.override.md`.
 
 Some command workflows still live in `rapid_os.cli.main` because moving them wholesale into new abstractions would be a larger behavior-changing rewrite. The priority here is to isolate reusable logic first, then migrate command domains incrementally.
 

--- a/rapid_os/adapters/mcp/__init__.py
+++ b/rapid_os/adapters/mcp/__init__.py
@@ -1,0 +1,5 @@
+"""MCP renderers for Rapid OS outputs."""
+
+from rapid_os.adapters.mcp.claude_desktop import render_claude_desktop_config
+
+__all__ = ["render_claude_desktop_config"]

--- a/rapid_os/adapters/mcp/claude_desktop.py
+++ b/rapid_os/adapters/mcp/claude_desktop.py
@@ -1,0 +1,13 @@
+def render_claude_desktop_config(mcp_config):
+    servers = {}
+    for server in mcp_config.servers:
+        definition = dict(server.extra or {})
+        definition.update({
+            "command": server.command,
+            "args": list(server.args),
+        })
+        if server.env:
+            definition["env"] = dict(server.env)
+        servers[server.id] = definition
+
+    return {"mcpServers": servers}

--- a/rapid_os/cli/main.py
+++ b/rapid_os/cli/main.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 from rapid_os.adapters.agents import DEFAULT_AGENT_REGISTRY
+from rapid_os.adapters.mcp import render_claude_desktop_config
 from rapid_os.core.config import load_project_config, save_project_config
 from rapid_os.core.context import compose_project_context
 from rapid_os.core.filesystem import check_node_installed, create_backup
@@ -25,6 +26,7 @@ from rapid_os.core.paths import (
     TEMPLATES_DIR,
 )
 from rapid_os.domain.agents import generate_agent_contexts
+from rapid_os.domain.mcp import build_mcp_config
 from rapid_os.domain.scanner import scan_project, suggest_init_choices
 from rapid_os.domain.scope import (
     ScopeSpec,
@@ -391,58 +393,18 @@ def generate_mcp_config(args):
     if not topo_file.exists():
         print_error("Ejecuta 'init' primero.")
 
-    topo_content = topo_file.read_text(encoding="utf-8").lower()
-    mcp_config = {"mcpServers": {}}
-
-    mcp_config["mcpServers"]["filesystem"] = {
-        "command": "npx",
-        "args": ["-y", "@modelcontextprotocol/server-filesystem", str(CURRENT_DIR)],
-    }
-
-    if "postgres" in topo_content and "supabase" not in topo_content:
-        tpl_path = TEMPLATES_DIR / "mcp" / "postgres.json"
-        if tpl_path.exists():
-            try:
-                mcp_config["mcpServers"].update(json.loads(tpl_path.read_text()))
-            except Exception:
-                pass
-
-    if "supabase" in topo_content:
-        tpl_path = TEMPLATES_DIR / "mcp" / "supabase.json"
-        if tpl_path.exists():
-            try:
-                mcp_config["mcpServers"].update(json.loads(tpl_path.read_text()))
-            except Exception:
-                pass
-
-    # --- RESEARCH TOOLS ---
+    topo_content = topo_file.read_text(encoding="utf-8")
     config = load_project_config(CONFIG_FILE)
     tools = config.get("tools", [])
+    mcp_config = build_mcp_config(topo_content, tools, CURRENT_DIR, TEMPLATES_DIR)
 
-    if "context7" in tools:
-        mcp_config["mcpServers"]["context7"] = {
-            "command": "npx",
-            "args": ["-y", "@upstash/context7-mcp"],
-            "env": {"CONTEXT7_API_KEY": "YOUR_API_KEY_HERE"},  # User must fill this
-        }
-        print_warning(
-            "⚠️  Context7 agregado. Recuerda poner tu API KEY en claude_desktop_config.json"
-        )
-
-    if "firecrawl" in tools:
-        mcp_config["mcpServers"]["firecrawl"] = {
-            "command": "npx",
-            "args": ["-y", "firecrawl-mcp"],
-            "env": {"FIRECRAWL_API_KEY": "YOUR_API_KEY_HERE"},  # User must fill this
-        }
-        print_warning(
-            "⚠️  Firecrawl agregado. Recuerda poner tu API KEY en claude_desktop_config.json"
-        )
+    for warning in mcp_config.warnings:
+        print_warning(warning.message)
 
     target = CURRENT_DIR / "claude_desktop_config.json"
     create_backup(target)
     with open(target, "w", encoding="utf-8") as f:
-        json.dump(mcp_config, f, indent=2)
+        json.dump(render_claude_desktop_config(mcp_config), f, indent=2)
     print_success(f"Configuración MCP: {target.name}")
 
 

--- a/rapid_os/domain/mcp.py
+++ b/rapid_os/domain/mcp.py
@@ -1,0 +1,266 @@
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+
+PLACEHOLDER_VALUES = (
+    "YOUR_API_KEY_HERE",
+    "[PASSWORD]",
+    "[PROJECT-ID]",
+    "postgresql://user:password@localhost:5432/dbname",
+)
+
+
+@dataclass(frozen=True)
+class McpServer:
+    id: str
+    command: str
+    args: tuple[str, ...] = ()
+    env: Mapping[str, str] | None = None
+    extra: Mapping[str, object] | None = None
+    source: str = "generated"
+
+
+@dataclass(frozen=True)
+class McpWarning:
+    code: str
+    message: str
+    server_id: str | None = None
+    path: Path | None = None
+
+
+@dataclass(frozen=True)
+class McpConfig:
+    servers: tuple[McpServer, ...] = ()
+    warnings: tuple[McpWarning, ...] = ()
+
+    def server_ids(self):
+        return tuple(server.id for server in self.servers)
+
+
+def build_mcp_config(
+    topology_content: str,
+    selected_tools,
+    current_dir: Path,
+    templates_dir: Path,
+):
+    normalized_topology = topology_content.lower()
+    selected_tools = set(selected_tools or [])
+    servers = [filesystem_server(current_dir)]
+    warnings = []
+
+    if "postgres" in normalized_topology and "supabase" not in normalized_topology:
+        template_servers, template_warnings = load_template_servers(
+            templates_dir / "mcp" / "postgres.json"
+        )
+        servers.extend(template_servers)
+        warnings.extend(template_warnings)
+
+    if "supabase" in normalized_topology:
+        template_servers, template_warnings = load_template_servers(
+            templates_dir / "mcp" / "supabase.json"
+        )
+        servers.extend(template_servers)
+        warnings.extend(template_warnings)
+
+    if "context7" in selected_tools:
+        servers.append(context7_server())
+    if "firecrawl" in selected_tools:
+        servers.append(firecrawl_server())
+
+    for server in servers:
+        warnings.extend(detect_server_warnings(server))
+
+    return McpConfig(tuple(servers), tuple(warnings))
+
+
+def filesystem_server(current_dir: Path):
+    return McpServer(
+        id="filesystem",
+        command="npx",
+        args=("-y", "@modelcontextprotocol/server-filesystem", str(current_dir)),
+        source="generated",
+    )
+
+
+def context7_server():
+    return McpServer(
+        id="context7",
+        command="npx",
+        args=("-y", "@upstash/context7-mcp"),
+        env={"CONTEXT7_API_KEY": "YOUR_API_KEY_HERE"},
+        source="generated",
+    )
+
+
+def firecrawl_server():
+    return McpServer(
+        id="firecrawl",
+        command="npx",
+        args=("-y", "firecrawl-mcp"),
+        env={"FIRECRAWL_API_KEY": "YOUR_API_KEY_HERE"},
+        source="generated",
+    )
+
+
+def load_template_servers(template_path: Path):
+    if not template_path.exists():
+        return (), (
+            McpWarning(
+                "MCP001",
+                f"MCP template not found: {template_path.name}",
+                path=template_path,
+            ),
+        )
+
+    try:
+        payload = json.loads(template_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return (), (
+            McpWarning(
+                "MCP002",
+                f"MCP template JSON is invalid: {exc.msg}",
+                path=template_path,
+            ),
+        )
+    except OSError as exc:
+        return (), (
+            McpWarning(
+                "MCP003",
+                f"MCP template could not be read: {exc}",
+                path=template_path,
+            ),
+        )
+
+    if not isinstance(payload, dict):
+        return (), (
+            McpWarning(
+                "MCP004",
+                "MCP template must contain an object of server definitions.",
+                path=template_path,
+            ),
+        )
+
+    servers = []
+    warnings = []
+    for server_id, definition in payload.items():
+        server, server_warnings = server_from_mapping(
+            server_id,
+            definition,
+            source=str(template_path),
+            path=template_path,
+        )
+        if server:
+            servers.append(server)
+        warnings.extend(server_warnings)
+
+    return tuple(servers), tuple(warnings)
+
+
+def server_from_mapping(server_id, definition, source="mapping", path=None):
+    warnings = []
+    if not isinstance(definition, dict):
+        return None, (
+            McpWarning(
+                "MCP005",
+                f"MCP server '{server_id}' definition must be an object.",
+                server_id=server_id,
+                path=path,
+            ),
+        )
+
+    command = definition.get("command")
+    if not command:
+        warnings.append(
+            McpWarning(
+                "MCP006",
+                f"MCP server '{server_id}' is missing command.",
+                server_id=server_id,
+                path=path,
+            )
+        )
+        return None, tuple(warnings)
+
+    args = definition.get("args", ())
+    if args is None:
+        args = ()
+    if not isinstance(args, list):
+        warnings.append(
+            McpWarning(
+                "MCP007",
+                f"MCP server '{server_id}' args should be a list.",
+                server_id=server_id,
+                path=path,
+            )
+        )
+        args = ()
+
+    env = definition.get("env")
+    if env is not None and not isinstance(env, dict):
+        warnings.append(
+            McpWarning(
+                "MCP008",
+                f"MCP server '{server_id}' env should be an object.",
+                server_id=server_id,
+                path=path,
+            )
+        )
+        env = None
+
+    known_keys = {"command", "args", "env"}
+    extra = {key: value for key, value in definition.items() if key not in known_keys}
+
+    return (
+        McpServer(
+            id=str(server_id),
+            command=str(command),
+            args=tuple(str(arg) for arg in args),
+            env=env,
+            extra=extra or None,
+            source=source,
+        ),
+        tuple(warnings),
+    )
+
+
+def detect_server_warnings(server: McpServer):
+    warnings = []
+    values = [server.command, *server.args]
+    if server.env:
+        values.extend(server.env.values())
+
+    for value in values:
+        for placeholder in PLACEHOLDER_VALUES:
+            if placeholder in str(value):
+                warnings.append(
+                    McpWarning(
+                        "MCP009",
+                        f"MCP server '{server.id}' contains unresolved placeholder: {placeholder}",
+                        server_id=server.id,
+                    )
+                )
+
+    if server.id == "context7" and (
+        not server.env or not server.env.get("CONTEXT7_API_KEY")
+    ):
+        warnings.append(
+            McpWarning(
+                "MCP010",
+                "Context7 MCP server is missing CONTEXT7_API_KEY.",
+                server_id=server.id,
+            )
+        )
+
+    if server.id == "firecrawl" and (
+        not server.env or not server.env.get("FIRECRAWL_API_KEY")
+    ):
+        warnings.append(
+            McpWarning(
+                "MCP011",
+                "Firecrawl MCP server is missing FIRECRAWL_API_KEY.",
+                server_id=server.id,
+            )
+        )
+
+    return tuple(warnings)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,238 @@
+import argparse
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+from rapid_os.adapters.mcp import render_claude_desktop_config
+from rapid_os.cli import main as cli_main
+from rapid_os.domain.mcp import (
+    McpConfig,
+    McpServer,
+    build_mcp_config,
+    context7_server,
+    detect_server_warnings,
+    filesystem_server,
+    firecrawl_server,
+    load_template_servers,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def workspace_tempdir():
+    return tempfile.TemporaryDirectory(dir=REPO_ROOT)
+
+
+def create_mcp_templates(root: Path):
+    templates_dir = root / "templates"
+    mcp_dir = templates_dir / "mcp"
+    mcp_dir.mkdir(parents=True)
+    (mcp_dir / "postgres.json").write_text(
+        json.dumps(
+            {
+                "postgres": {
+                    "command": "docker",
+                    "args": [
+                        "run",
+                        "-i",
+                        "--rm",
+                        "-e",
+                        "POSTGRES_CONNECTION_STRING=postgresql://user:password@localhost:5432/dbname",
+                        "mcp/postgres",
+                    ],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (mcp_dir / "supabase.json").write_text(
+        json.dumps(
+            {
+                "supabase": {
+                    "command": "npx",
+                    "args": [
+                        "-y",
+                        "@modelcontextprotocol/server-postgres",
+                        "postgresql://postgres:[PASSWORD]@db.[PROJECT-ID].supabase.co:6543/postgres?pgbouncer=true",
+                    ],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    return templates_dir
+
+
+class McpDomainTests(unittest.TestCase):
+    def test_filesystem_server_model(self):
+        server = filesystem_server(Path("project"))
+
+        self.assertEqual(server.id, "filesystem")
+        self.assertEqual(server.command, "npx")
+        self.assertEqual(
+            server.args,
+            ("-y", "@modelcontextprotocol/server-filesystem", "project"),
+        )
+
+    def test_research_server_models(self):
+        context7 = context7_server()
+        firecrawl = firecrawl_server()
+
+        self.assertEqual(context7.id, "context7")
+        self.assertEqual(context7.env["CONTEXT7_API_KEY"], "YOUR_API_KEY_HERE")
+        self.assertEqual(firecrawl.id, "firecrawl")
+        self.assertEqual(firecrawl.env["FIRECRAWL_API_KEY"], "YOUR_API_KEY_HERE")
+
+    def test_build_config_includes_filesystem_by_default(self):
+        with workspace_tempdir() as tmp:
+            templates_dir = create_mcp_templates(Path(tmp))
+
+            config = build_mcp_config("", [], Path(tmp), templates_dir)
+
+            self.assertEqual(config.server_ids(), ("filesystem",))
+
+    def test_postgres_topology_loads_postgres_template(self):
+        with workspace_tempdir() as tmp:
+            templates_dir = create_mcp_templates(Path(tmp))
+
+            config = build_mcp_config(
+                "Database: PostgreSQL", [], Path(tmp), templates_dir
+            )
+
+            self.assertIn("filesystem", config.server_ids())
+            self.assertIn("postgres", config.server_ids())
+            self.assertNotIn("supabase", config.server_ids())
+
+    def test_supabase_topology_loads_supabase_template_not_postgres(self):
+        with workspace_tempdir() as tmp:
+            templates_dir = create_mcp_templates(Path(tmp))
+
+            config = build_mcp_config(
+                "Database: Supabase Postgres", [], Path(tmp), templates_dir
+            )
+
+            self.assertIn("supabase", config.server_ids())
+            self.assertNotIn("postgres", config.server_ids())
+
+    def test_selected_research_tools_add_servers(self):
+        with workspace_tempdir() as tmp:
+            templates_dir = create_mcp_templates(Path(tmp))
+
+            config = build_mcp_config(
+                "", ["context7", "firecrawl"], Path(tmp), templates_dir
+            )
+
+            self.assertIn("context7", config.server_ids())
+            self.assertIn("firecrawl", config.server_ids())
+
+    def test_renderer_outputs_current_claude_desktop_shape(self):
+        with workspace_tempdir() as tmp:
+            templates_dir = create_mcp_templates(Path(tmp))
+            config = build_mcp_config(
+                "", ["context7"], Path("project"), templates_dir
+            )
+
+            rendered = render_claude_desktop_config(config)
+
+            self.assertEqual(set(rendered), {"mcpServers"})
+            self.assertIn("filesystem", rendered["mcpServers"])
+            self.assertEqual(
+                rendered["mcpServers"]["context7"]["env"],
+                {"CONTEXT7_API_KEY": "YOUR_API_KEY_HERE"},
+            )
+
+    def test_renderer_preserves_extra_template_fields(self):
+        config = McpConfig(
+            (
+                McpServer(
+                    id="custom",
+                    command="npx",
+                    args=("-y", "custom-mcp"),
+                    extra={"transport": "stdio"},
+                ),
+            )
+        )
+
+        rendered = render_claude_desktop_config(config)
+
+        self.assertEqual(
+            rendered["mcpServers"]["custom"],
+            {
+                "transport": "stdio",
+                "command": "npx",
+                "args": ["-y", "custom-mcp"],
+            },
+        )
+
+    def test_invalid_template_json_returns_warning_without_crashing(self):
+        with workspace_tempdir() as tmp:
+            path = Path(tmp) / "templates" / "mcp" / "postgres.json"
+            path.parent.mkdir(parents=True)
+            path.write_text("{invalid", encoding="utf-8")
+
+            servers, warnings = load_template_servers(path)
+
+            self.assertEqual(servers, ())
+            self.assertEqual(warnings[0].code, "MCP002")
+
+    def test_placeholder_warnings_are_non_blocking(self):
+        server = context7_server()
+
+        warnings = detect_server_warnings(server)
+
+        self.assertTrue(any(warning.code == "MCP009" for warning in warnings))
+
+    def test_missing_research_tool_keys_are_warnings(self):
+        warnings = detect_server_warnings(
+            McpServer(id="context7", command="npx", args=("-y", "@upstash/context7-mcp"))
+        )
+
+        self.assertTrue(any(warning.code == "MCP010" for warning in warnings))
+
+
+class McpCliTests(unittest.TestCase):
+    def test_generate_mcp_config_writes_compatible_claude_desktop_json(self):
+        with workspace_tempdir() as tmp:
+            root = Path(tmp)
+            current_dir = root / "project"
+            project_dir = current_dir / ".rapid-os"
+            standards_dir = project_dir / "standards"
+            standards_dir.mkdir(parents=True)
+            templates_dir = create_mcp_templates(root)
+
+            (standards_dir / "topology.md").write_text(
+                "Database: Supabase", encoding="utf-8"
+            )
+            (project_dir / "config.json").write_text(
+                json.dumps({"tools": ["context7"]}), encoding="utf-8"
+            )
+
+            with patch.object(cli_main, "CURRENT_DIR", current_dir), patch.object(
+                cli_main, "PROJECT_RAPID_DIR", project_dir
+            ), patch.object(cli_main, "CONFIG_FILE", project_dir / "config.json"), patch.object(
+                cli_main, "TEMPLATES_DIR", templates_dir
+            ), redirect_stdout(
+                io.StringIO()
+            ):
+                cli_main.generate_mcp_config(argparse.Namespace())
+
+            payload = json.loads(
+                (current_dir / "claude_desktop_config.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+
+            self.assertIn("mcpServers", payload)
+            self.assertIn("filesystem", payload["mcpServers"])
+            self.assertIn("supabase", payload["mcpServers"])
+            self.assertIn("context7", payload["mcpServers"])
+            self.assertNotIn("postgres", payload["mcpServers"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This PR adds the Rapid OS v2 MCP abstraction layer.

## What changed
- added a pure MCP domain model for server definitions, generation planning, and warnings
- added a renderer layer for the current Claude Desktop output format
- refactored `rapid mcp` to use the MCP domain model and renderer while keeping the CLI as the write/backup facade
- preserved support for current MCP server types:
  - filesystem
  - postgres
  - supabase
  - context7
  - firecrawl
- added non-blocking warnings for unresolved placeholders and missing research-tool keys
- added tests and docs

## Compatibility
- `rapid mcp` still writes `claude_desktop_config.json`
- the current `mcpServers` JSON shape remains supported
- existing generated files, adapters, validation commands, scanner, Codex behavior, scope generation, install scripts, templates, and config shape remain unchanged
- placeholder and missing-key warnings do not block generation

## Validation
- Ran the full unittest suite: `Ran 74 tests ... OK`

## Follow-up
Future improvements may include additional MCP output destinations, richer secret/key resolution, MCP profiles, and deeper provider support.